### PR TITLE
Gatling Enterprise upload package, closes MISC-230 & MISC-242

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,11 @@ scalaVersion := "2.12.13"
 sbtPlugin := true
 githubPath := "gatling/gatling-sbt-plugin"
 
-libraryDependencies += "org.scalatest"     %% "scalatest" % "3.2.9" % "test"
-libraryDependencies += "org.zeroturnaround" % "zt-zip"    % "1.14"
+libraryDependencies ++= Seq(
+  "org.scalatest"     %% "scalatest"                         % "3.2.9" % Test,
+  "org.zeroturnaround" % "zt-zip"                            % "1.14",
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "0.0.3"
+)
 
 scriptedLaunchOpts := {
   scriptedLaunchOpts.value ++

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -30,12 +30,21 @@ object GatlingKeys {
   val assembly = taskKey[File](
     "Builds a package for Gatling Enterprise (deprecated, please use 'Gatling / enterpriseAssembly' or 'GatlingIt / enterpriseAssembly' instead)."
   )
-  val enterpriseAssembly = taskKey[File]("Builds a package for Gatling Enterprise.")
+  val enterpriseAssembly = taskKey[File]("Builds a package for Gatling Enterprise")
+  val enterprisePublish = taskKey[Unit]("Publish a package for Gatling Enterprise")
   val startRecorder = inputKey[Unit]("Start Gatling's Recorder")
   val lastReport = inputKey[Unit]("Open last Gatling report in browser")
   val copyConfigFiles = taskKey[Set[File]]("Copy Gatling's config files if missing")
   val copyLogbackXml = taskKey[File]("Copy Gatling's default logback.xml if missing")
   val generateReport = inputKey[Unit]("Generate report for a specific simulation")
+
+  // -------------- //
+  // -- Settings -- //
+  // -------------- //
+
+  val enterpriseUrl = settingKey[URL]("Target URL on Gatling Enterprise")
+  val enterprisePackageId = settingKey[String]("Target package ID on Gatling Enterprise")
+  val enterpriseApiToken = settingKey[String]("API Token for package upload on Gatling Enterprise")
 
   // -------------------- //
   // -- Configurations -- //

--- a/src/main/scala/io/gatling/sbt/GatlingPlugin.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingPlugin.scala
@@ -90,7 +90,11 @@ object GatlingPlugin extends AutoPlugin {
     config / copyConfigFiles := copyConfigurationFiles((config / resourceDirectory).value, (config / update).value),
     config / copyLogbackXml := copyLogback((config / resourceDirectory).value, (config / update).value),
     config / generateReport := generateGatlingReport(config).evaluated,
-    config / enterpriseAssembly := packageEnterpriseJar(config).value
+    config / enterpriseUrl := new URL("https://cloud.gatling.io/api/public"),
+    config / enterpriseAssembly := packageEnterpriseJar(config).value,
+    config / enterprisePublish := publishEnterpriseJar(config).value,
+    config / enterprisePackageId := "",
+    config / enterpriseApiToken := sys.props.get("gatling.enterprise.apiToken").orElse(sys.env.get("GATLING_ENTERPRISE_API_TOKEN")).getOrElse("")
   )
 
   /**

--- a/src/main/scala/io/gatling/sbt/utils/FatJar.scala
+++ b/src/main/scala/io/gatling/sbt/utils/FatJar.scala
@@ -32,8 +32,9 @@ object FatJar {
       workingDir => {
         extractDependencies(workingDir, dependencies)
         copyClasses(workingDir, classesDirectory)
-        generateManifest(workingDir, rootModule)
-        generateVersionFile(workingDir, gatlingVersion)
+        generateManifest(workingDir, rootModule, gatlingVersion)
+        generatePomProperties(workingDir, rootModule)
+        generatePomXml(workingDir, rootModule)
 
         val fatJarFile = target / s"$jarName.jar"
         target.mkdirs()
@@ -54,28 +55,48 @@ object FatJar {
       FileUtilsV2_2.copyDirectory(directory, workingDir, pathname => !isExcluded(directoryPath.relativize(pathname.toPath).toString), false)
     }
 
-  private def generateManifest(workingDir: File, rootModule: ModuleID): Unit = {
+  private def generateManifest(workingDir: File, rootModule: ModuleID, gatlingVersion: String): Unit = {
     val manifest = s"""Manifest-Version: 1.0
                       |Implementation-Title: ${rootModule.name}
+                      |Implementation-Vendor: ${rootModule.organization}
                       |Implementation-Version: ${rootModule.revision}
-                      |Specification-Vendor: ${rootModule.organization}
-                      |Implementation-Vendor: GatlingCorp
+                      |Specification-Vendor: GatlingCorp
+                      |Gatling-Version: $gatlingVersion
                       |""".stripMargin
 
     IO.write(workingDir / "META-INF" / "MANIFEST.MF", manifest)
   }
 
-  private def generateVersionFile(workingDir: File, gatlingVersion: String): Unit = {
-    val content = s"gatling-compile-version=$gatlingVersion"
-    IO.write(workingDir / "META-INF" / "gatling-compile-version.properties", content)
+  private def generatePomProperties(workingDir: File, rootModule: ModuleID): Unit = {
+    val content =
+      s"""groupId=${rootModule.organization}
+         |artifactId=${rootModule.name}
+         |version=${rootModule.revision}
+         |""".stripMargin
+
+    IO.write(workingDir / "META-INF" / "maven" / rootModule.organization / rootModule.name / "pom.properties", content)
+  }
+
+  private def generatePomXml(workingDir: File, rootModule: ModuleID): Unit = {
+    val content =
+      s"""<?xml version="1.0" encoding="UTF-8"?>
+         |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         |         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         |  <modelVersion>4.0.0</modelVersion>
+         |  <groupId>${rootModule.organization}</groupId>
+         |  <artifactId>${rootModule.name}</artifactId>
+         |  <version>${rootModule.revision}</version>
+         |</project>""".stripMargin
+
+    IO.write(workingDir / "META-INF" / "maven" / rootModule.organization / rootModule.name / "pom.xml", content)
   }
 
   private def isExcluded(name: String): Boolean =
     name.equalsIgnoreCase("META-INF/LICENSE") ||
       name.equalsIgnoreCase("META-INF/MANIFEST.MF") ||
+      name.startsWith("META-INF/versions/") ||
+      name.startsWith("META-INF/maven/") ||
       name.endsWith(".SF") ||
       name.endsWith(".DSA") ||
-      name.endsWith(".RSA") ||
-      name.startsWith("META-INF/maven/") ||
-      name.startsWith("META-INF/versions/")
+      name.endsWith(".RSA")
 }


### PR DESCRIPTION
### Gatling Enterprise upload package, closes MISC-230

**Motivation:**
Upload artifact from maven plugin on Gatling Enterprise

**Modification:**
* Use `gatling-enterprise-plugin-commons` enterprise client to upload
* Add `Gatling / enterprisePublish` task to upload package

**Result:**
Upload using `Gatling / enterprisePublish`.
Need configuration of `enterprisePackageId` and `enterpriseApiToken`.

---

### Add back missing features from sbt-frontline, closes MISC-242 

**Motivation:**

missing:
* Gatling-Version in manifest
* maven properties and pom
* Netty dependencies exclusion

**Modifications:**
Add missing features back
