### PR TITLE
fix: sbt 1.5.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7


### PR DESCRIPTION
sbt 1.5.7 updates log4j 2 to 2.16.0, which disables JNDI lookup and fixes a denial of service vulnerability
https://github.com/sbt/sbt/releases/tag/v1.5.7