### PR TITLE
feat: add enterprise interactive create or start simulation, closes MISC-316

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.10" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.14",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "0.0.3-M20211221165132"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "0.0.3-M20220104165451"
 )
 
 scriptedLaunchOpts := {

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -45,6 +45,7 @@ object GatlingKeys {
   val enterprisePackage = taskKey[File]("Build a package for Gatling Enterprise")
   val enterpriseUpload = taskKey[Unit]("Upload a package for Gatling Enterprise")
   val enterpriseStart = taskKey[Unit]("Start a simulation for Gatling Enterprise")
+  val enterpriseInteractiveStart = taskKey[Unit]("Start a simulation interactively for Gatling Enterprise")
   val assembly = taskKey[File](
     "Builds a package for Gatling Enterprise (deprecated, please use 'Gatling / enterprisePackage' or 'GatlingIt / enterprisePackage' instead)."
   )


### PR DESCRIPTION
**Motivation:**
We wan't our user to be able to configure interactively a simulation from plugins.

**Modification:**
* Update enterprise plugin common to benefit from interactive features
* Integrate new avaiable create or start interactively feature from common

**Ref:** MISC-316