### PR TITLE
update: gatling-build-plugin to 4.3.0

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: 'milestone|patch|minor'
+        description: 'patch-milestone|minor-milestone|patch|minor'
         required: true
 
 defaults:
@@ -24,7 +24,8 @@ jobs:
         if: |
           github.event.inputs.releaseType != 'minor' &&
           github.event.inputs.releaseType != 'patch' &&
-          github.event.inputs.releaseType != 'milestone'
+          github.event.inputs.releaseType != 'minor-milestone' &&
+          github.event.inputs.releaseType != 'patch-milestone'
 
       - uses: actions/checkout@v2
         with:
@@ -61,7 +62,7 @@ jobs:
         run: |
           git config user.name "${{ secrets.GATLING_CI_NAME }}"
           git config user.email "${{ secrets.GATLING_CI_EMAIL }}"
-          if [ "${{github.event.inputs.releaseType}}" = "milestone" ]; then
+          if [ "${{github.event.inputs.releaseType}}" = "minor-milestone" || "${{github.event.inputs.releaseType}}" = "patch-milestone" ]; then
             git tag "${{ steps.tag.outputs.tag }}"
           else
             git tag "${{ steps.tag.outputs.tag }}" -m "Version ${{ steps.tag.outputs.tag }}"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.gatling"   % "gatling-build-plugin" % "4.2.0")
+addSbtPlugin("io.gatling"   % "gatling-build-plugin" % "4.3.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo"        % "0.10.0")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
Motivation:
milestone qualified version should be before stable version (of the same x.y.z numbers)

Modifications:
 * Update gatling-build-plugin to 4.3.0
 * Update available milestone related command to create a new release