### PR TITLE
feat: remove cancel information from readString, closes MISC-346

### DIFF
--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -139,7 +139,7 @@ object EnterpriseSettings {
     new PluginIO {
       override def getLogger: PluginLogger = logger
       override def getScanner: PluginScanner = new PluginScanner {
-        override def readString(): String = interactiveService.readLine("(ctrl+x+c to cancel) > ", mask = false).getOrElse("")
+        override def readString(): String = interactiveService.readLine("> ", mask = false).getOrElse("")
         override def readInt(): Int = Integer.parseInt(readString())
       }
     }


### PR DESCRIPTION
**Motivation:**
SBT 1.6.2 fix the problem, and standard ctrl+c works well

**Modification:**
Remove prefix indicating shortcut on readString