### PR TITLE
feat: delegate simulation classes discovery to commons and allow simulation start override

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.11" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.15",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.0.3-M1"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.0.3-SNAPSHOT"
 )
 
 scriptedLaunchOpts := {
@@ -34,6 +34,11 @@ gatlingDevelopers := Seq(
   GatlingDeveloper(
     "sbrevet@gatling.io",
     "Sébastien Brevet",
+    true
+  ),
+  GatlingDeveloper(
+    "tpetillot@gatling.io",
+    "Thomas Petillot",
     true
   )
 )


### PR DESCRIPTION
**Motivation:**
Allow to start a simulation configured with a non-discovered class name, by overriding the value based on plugin configuration or by client input.

**Modifications:**
* Delegate simulations discovery to commons library
* Pass configured class name along redefined commons method signatures
* Handle introduced exceptions

**Ref:** MISC-348