### PR TITLE
fix: exclude module-info from fat jar

### DIFF
--- a/src/main/scala/io/gatling/sbt/utils/FatJar.scala
+++ b/src/main/scala/io/gatling/sbt/utils/FatJar.scala
@@ -94,6 +94,7 @@ object FatJar {
   private def isExcluded(name: String): Boolean =
     name.equalsIgnoreCase("META-INF/LICENSE") ||
       name.equalsIgnoreCase("META-INF/MANIFEST.MF") ||
+      name.equalsIgnoreCase("module-info.class") ||
       name.startsWith("META-INF/versions/") ||
       name.startsWith("META-INF/maven/") ||
       name.endsWith(".SF") ||


### PR DESCRIPTION
**Ref:** MISC-365