### PR TITLE
feat: handle unsupported version exception, closes MISC-372

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.11" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.15",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.1.1"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.1.2"
 )
 
 scriptedLaunchOpts := {

--- a/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
@@ -30,6 +30,14 @@ import sbt.internal.util.ManagedLogger
 class RecoverEnterprisePluginException(config: Configuration) {
 
   protected def recoverEnterprisePluginException[U](logger: ManagedLogger): PartialFunction[Throwable, Try[U]] = {
+    case e: UnsupportedJavaVersionException =>
+      logger.error(s"""${e.getMessage}
+                      |In order to target the supported Java bytecode version, please use the following sbt settings:
+                      |scalacOptions += "-target:${e.supportedVersion}"
+                      |javacOptions ++= Seq("--release", "${e.supportedVersion}")
+                      |Or, reported class may come from your project dependencies, published targeting Java ${e.version}.
+                      |""".stripMargin)
+      Failure(ErrorAlreadyLoggedException)
     case e: SeveralTeamsFoundException =>
       val teams = e.getAvailableTeams.asScala
       logger.error(s"""More than 1 team were found while creating a simulation.

--- a/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.sbt.settings.gatling
+
+import java.util.UUID
+
+import scala.jdk.CollectionConverters._
+import scala.util.{ Failure, Try }
+
+import io.gatling.plugin.exceptions._
+import io.gatling.plugin.model.Simulation
+
+import sbt.Configuration
+import sbt.internal.util.ManagedLogger
+
+class RecoverEnterprisePluginException(config: Configuration) {
+
+  protected def recoverEnterprisePluginException[U](logger: ManagedLogger): PartialFunction[Throwable, Try[U]] = {
+    case e: SeveralTeamsFoundException =>
+      val teams = e.getAvailableTeams.asScala
+      logger.error(s"""More than 1 team were found while creating a simulation.
+                      |Available teams:
+                      |${teams.map(team => s"- ${team.id} (${team.name})").mkString("\n")}
+                      |Specify the team you want to use with -Dgatling.enterprise.teamId=<teamId>, or add the configuration to your build.sbt, e.g.:
+                      |${config.id} / enterpriseTeamId := "${teams.head.id}"
+                      |""".stripMargin)
+      Failure(ErrorAlreadyLoggedException)
+    case e: SeveralSimulationClassNamesFoundException =>
+      val simulationClasses = e.getAvailableSimulationClassNames.asScala
+      logger.error(
+        s"""Several simulation classes were found
+           |${simulationClasses.map("- " + _).mkString("\n")}
+           |Specify the simulation you want to use with -Dgatling.enterprise.simulationClass=<className>, or add the configuration to your build.sbt, e.g.:
+           |${config.id} / simulationClass := "${simulationClasses.head}"
+           |""".stripMargin
+      )
+      Failure(ErrorAlreadyLoggedException)
+    case e: UserQuitException =>
+      logger.warn(e.getMessage)
+      Failure(ErrorAlreadyLoggedException)
+    case e: SimulationStartException =>
+      if (e.isCreated) {
+        logCreatedSimulation(logger, e.getSimulation)
+      }
+      logSimulationConfiguration(logger, e.getSimulation.id)
+      Failure(e.getCause)
+  }
+
+  protected def logCreatedSimulation(logger: ManagedLogger, simulation: Simulation): Unit =
+    logger.info(s"Created simulation named ${simulation.name} with ID '${simulation.id}'")
+
+  protected def logSimulationConfiguration(logger: ManagedLogger, simulationId: UUID): Unit =
+    logger.info(
+      s"""To start again the same simulation, specify -Dgatling.enterprise.simulationId=$simulationId, or add the configuration to your SBT settings, e.g.:
+         |${config.id} / enterpriseSimulationId := "$simulationId"
+         |""".stripMargin
+    )
+}

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
@@ -21,7 +21,7 @@ import java.io.File
 import io.gatling.sbt.settings.gatling.EnterpriseUtils.InitializeTask
 import io.gatling.sbt.utils._
 
-import sbt.{ Configuration, Def, IntegrationTest, ModuleDescriptorConfiguration, Test, ThisScope }
+import sbt.{ Configuration, Def, IntegrationTest, ModuleDescriptorConfiguration, Test }
 import sbt.Keys._
 
 class TaskEnterprisePackage(config: Configuration) {

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
@@ -18,16 +18,17 @@ package io.gatling.sbt.settings.gatling
 
 import java.util.UUID
 
-import scala.util.{ Try, Using }
+import scala.util.Using
 
 import io.gatling.sbt.GatlingKeys._
+import io.gatling.sbt.settings.gatling.EnterpriseUtils._
 
 import sbt._
 import sbt.Keys.streams
 
-class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterprisePackage) {
+class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterprisePackage) extends RecoverEnterprisePluginException(config) {
 
-  val uploadEnterprisePackage: Def.Initialize[Task[Try[Unit]]] = Def.task {
+  val uploadEnterprisePackage: InitializeTask[Unit] = Def.task {
     val logger = streams.value.log
     val file = enterprisePackage.buildEnterprisePackage.value
     val settingPackageId = (config / enterprisePackageId).value
@@ -56,6 +57,6 @@ class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterpr
       }
 
       logger.success("Successfully upload package")
-    }
+    }.recoverWith(recoverEnterprisePluginException(logger)).get
   }
 }


### PR DESCRIPTION
chore: centralize plugin exception handling accross tasks
---

**Motivation:**
Recovering from error is always the same

**Modification:**
Add RecoverEnterprisePluginException to extend in order to get recovering method

feat: handle unsupported version exception, closes MISC-372
---

**Motivation:**
New commons version throw `UnsupportedJavaVersionException` when java version isn't supported by Gatling Enterprise CLoud

**Modification:**
Log exception message, along scala and java options to target a compatible bytecode.