### PR TITLE
Pass env variables and system props as string, closes CLOUD-368

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.12" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.15",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.1.2"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.2.0"
 )
 
 scriptedLaunchOpts := {

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -71,7 +71,29 @@ object GatlingKeys {
                           |""".stripMargin)
 
   val enterpriseSimulationSystemProperties = settingKey[Map[String, String]](
-    s"""Simulation system properties used when starting a simulation. Properties are merged with the one configured on the simulation.
+    s"""Provides additional system properties when starting a simulation, in addition to the ones which may already be defined for that simulation.
+       |${systemPropertyDescription("gatling.enterprise.simulationSystemProperties")} with the format key1=value1,key2=value2
+       |$documentationReference.
+       |""".stripMargin
+  )
+
+  val enterpriseSimulationSystemPropertiesString = settingKey[String](
+    s"""Alternative to enterpriseSimulationSystemProperties. Use the format key1=value1,key2=value2
+       |${systemPropertyDescription("gatling.enterprise.simulationSystemProperties")}.
+       |$documentationReference.
+       |""".stripMargin
+  )
+
+  val enterpriseSimulationEnvironmentVariables = settingKey[Map[String, String]](
+    s"""Provides additional environment variables when starting a simulation, in addition to the ones which may already be defined for that simulation.
+       |${systemPropertyDescription("gatling.enterprise.simulationEnvironmentVariables")} with the format key1=value1,key2=value2
+       |$documentationReference.
+       |""".stripMargin
+  )
+
+  val enterpriseSimulationEnvironmentVariablesString = settingKey[String](
+    s"""Alternative to enterpriseSimulationEnvironmentVariables. Use the format key1=value1,key2=value2.
+       |${systemPropertyDescription("gatling.enterprise.simulationEnvironmentVariables")}.
        |$documentationReference.
        |""".stripMargin
   )

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -57,6 +57,9 @@ object EnterpriseSettings {
       config / enterpriseTeamId := sys.props.get("gatling.enterprise.teamId").getOrElse(""),
       config / enterpriseSimulationId := sys.props.get("gatling.enterprise.simulationId").getOrElse(""),
       config / enterpriseSimulationSystemProperties := Map.empty,
+      config / enterpriseSimulationSystemPropertiesString := sys.props.get("gatling.enterprise.simulationSystemProperties").getOrElse(""),
+      config / enterpriseSimulationEnvironmentVariables := Map.empty,
+      config / enterpriseSimulationEnvironmentVariablesString := sys.props.get("gatling.enterprise.simulationEnvironmentVariables").getOrElse(""),
       config / enterpriseApiToken := sys.props.get("gatling.enterprise.apiToken").orElse(sys.env.get("GATLING_ENTERPRISE_API_TOKEN")).getOrElse(""),
       config / packageBin := (config / enterprisePackage).value, // If we directly use config / enterprisePackage for publishing, classifiers (-tests or -it) are not correctly handled.
       config / enterpriseSimulationClass := sys.props.get("gatling.enterprise.simulationClass").getOrElse("")


### PR DESCRIPTION
Motivation:

- system props can't be passed in the command line
- env variables can't be passed to the sbt plugin

Modifications:

- use new version of the enterprise commons plugin
- system props can be passed as a string in command line
- env variables can be passed as a string, or in the build.sbt file