### PR TITLE
chore: upgrade gatling-enterprise-plugin-commons to 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.12" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.15",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.2.0"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.3.0"
 )
 
 scriptedLaunchOpts := {

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseClient.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseClient.scala
@@ -16,7 +16,7 @@
 
 package io.gatling.sbt.settings.gatling
 
-import io.gatling.plugin.client.http.OkHttpEnterpriseClient
+import io.gatling.plugin.client.http.HttpEnterpriseClient
 import io.gatling.plugin.exceptions.UnsupportedClientException
 import io.gatling.sbt.BuildInfo
 import io.gatling.sbt.GatlingKeys._
@@ -42,7 +42,7 @@ object EnterpriseClient {
     }
 
     try {
-      new OkHttpEnterpriseClient(settingUrl, settingApiToken, BuildInfo.name, BuildInfo.version)
+      new HttpEnterpriseClient(settingUrl, settingApiToken, BuildInfo.name, BuildInfo.version)
     } catch {
       case _: UnsupportedClientException =>
         logger.error(

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseStart.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseStart.scala
@@ -20,7 +20,7 @@ import java.{ util => ju }
 import java.util.UUID
 
 import scala.jdk.CollectionConverters._
-import scala.util.Using
+import scala.util.Try
 
 import io.gatling.plugin.EnterprisePlugin
 import io.gatling.plugin.util.PropertiesParserUtil
@@ -48,9 +48,7 @@ class TaskEnterpriseStart(config: Configuration, enterprisePackage: TaskEnterpri
     val enterprisePlugin = enterprisePluginTask(batchMode).value
 
     logger.info(s"Uploading and starting simulation...")
-    Using(enterprisePlugin) { enterprisePlugin =>
-      enterprisePlugin.uploadPackageAndStartSimulation(simulationId, systemProperties, environmentVariables, simulationClassname.orNull, file)
-    }.get
+    enterprisePlugin.uploadPackageAndStartSimulation(simulationId, systemProperties, environmentVariables, simulationClassname.orNull, file)
   }
 
   private def enterpriseSimulationCreate(batchMode: Boolean) = Def.task {
@@ -64,7 +62,7 @@ class TaskEnterpriseStart(config: Configuration, enterprisePackage: TaskEnterpri
     val file = enterprisePackage.buildEnterprisePackage.value
     val enterprisePlugin = enterprisePluginTask(batchMode).value
 
-    Using(enterprisePlugin) { enterprisePlugin =>
+    Try {
       logger.info("Creating and starting simulation...")
       enterprisePlugin.createAndStartSimulation(
         optionalDefaultSimulationTeamId.orNull,

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
@@ -18,7 +18,7 @@ package io.gatling.sbt.settings.gatling
 
 import java.util.UUID
 
-import scala.util.Using
+import scala.util.Try
 
 import io.gatling.sbt.GatlingKeys._
 import io.gatling.sbt.settings.gatling.EnterpriseUtils._
@@ -33,9 +33,9 @@ class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterpr
     val file = enterprisePackage.buildEnterprisePackage.value
     val settingPackageId = (config / enterprisePackageId).value
     val settingSimulationId = (config / enterpriseSimulationId).value
-    val batchEnterprisePlugin = EnterprisePluginTask.batchEnterprisePluginTask(config).value
+    val enterprisePlugin = EnterprisePluginTask.batchEnterprisePluginTask(config).value
 
-    Using(batchEnterprisePlugin) { enterprisePlugin =>
+    Try {
       if (settingPackageId.isEmpty && settingSimulationId.isEmpty) {
         logger.error(
           s"""A package ID is required to upload a package on Gatling Enterprise; see https://gatling.io/docs/enterprise/cloud/reference/user/package_conf/, create a package and copy its ID.


### PR DESCRIPTION
Motivation:
OkHttpClient has CVE for older versions

Modifications:
 * upgrade gatling-enterprise-plugin-commons

Result:
Less dependencies to OkHttpClient (sbt has still a dependency)