### PR TITLE
Fix error handling for enterpriseStart with existing simulation, notably Java version errors

### DIFF
--- a/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
@@ -32,10 +32,11 @@ class RecoverEnterprisePluginException(config: Configuration) {
   protected def recoverEnterprisePluginException[U](logger: ManagedLogger): PartialFunction[Throwable, Try[U]] = {
     case e: UnsupportedJavaVersionException =>
       logger.error(s"""${e.getMessage}
-                      |In order to target the supported Java bytecode version, please use the following sbt settings:
-                      |scalacOptions += "-target:${e.supportedVersion}"
+                      |In order to target the supported Java version, please use the following sbt settings:
+                      |scalacOptions ++= Seq("-target:${e.supportedVersion}", "-release", "${e.supportedVersion}")
                       |javacOptions ++= Seq("--release", "${e.supportedVersion}")
-                      |Or, reported class may come from your project dependencies, published targeting Java ${e.version}.
+                      |See also the Scala compiler documentation: https://docs.scala-lang.org/overviews/compiler-options/index.html, and the Java compiler documentation: https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#compiling-for-earlier-releases-of-the-platform
+                      |Alternatively, the reported class may come from your project's dependencies, published targeting Java ${e.version}. In this case you need to use dependencies which target Java ${e.supportedVersion} or lower.
                       |""".stripMargin)
       Failure(ErrorAlreadyLoggedException)
     case e: SeveralTeamsFoundException =>

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseStart.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseStart.scala
@@ -47,11 +47,13 @@ class TaskEnterpriseStart(config: Configuration, enterprisePackage: TaskEnterpri
     val file = enterprisePackage.buildEnterprisePackage.value
     val enterprisePlugin = enterprisePluginTask(batchMode).value
 
-    logger.info(s"Uploading and starting simulation...")
-    enterprisePlugin.uploadPackageAndStartSimulation(simulationId, systemProperties, environmentVariables, simulationClassname.orNull, file)
+    Try {
+      logger.info(s"Uploading and starting simulation...")
+      enterprisePlugin.uploadPackageAndStartSimulation(simulationId, systemProperties, environmentVariables, simulationClassname.orNull, file)
+    }.recoverWith(recoverEnterprisePluginException(logger)).get
   }
 
-  private def enterpriseSimulationCreate(batchMode: Boolean) = Def.task {
+  private def createAndStartEnterpriseSimulation(batchMode: Boolean) = Def.task {
     val logger = streams.value.log
     val optionalDefaultSimulationTeamId = configOptionalString(config / enterpriseTeamId).value.map(UUID.fromString)
     val optionalPackageId = configOptionalString(config / enterprisePackageId).value.map(UUID.fromString)
@@ -84,7 +86,7 @@ class TaskEnterpriseStart(config: Configuration, enterprisePackage: TaskEnterpri
 
     settingSimulationId match {
       case Some(simulationId) => startEnterpriseSimulation(batchMode, simulationId)
-      case _                  => enterpriseSimulationCreate(batchMode)
+      case _                  => createAndStartEnterpriseSimulation(batchMode)
     }
   }
 


### PR DESCRIPTION
ref: MISC-397

Motivation:
When running enterpriseStart with a specified simulation, the error handler which handles standard errors from the common client is bypassed. This is notably seen for UnsupportedJavaVersionException. 

Modifications:
- Use the RecoverEnterprisePluginException handler regardless of whether we start an existing simulation or create a new one.
- Improve the error message in case of UnsupportedJavaVersionException.

Result:
Better information for the user in case of error.