### PR TITLE
feat: Add ability to monitor progress and wait for run end for enterpriseStart

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.15" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.15",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.4.12"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.5.1"
 )
 
 scriptedLaunchOpts := {

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -70,6 +70,14 @@ object GatlingKeys {
                           |$documentationReference.
                           |""".stripMargin)
 
+  val waitForRunEnd =
+    settingKey[Boolean](
+      s"""Wait for the result after starting the simulation on Gatling Enterprise, and complete with an error if the simulation ends with any error status.
+         |${systemPropertyDescription("gatling.enterprise.waitForRunEnd")}.
+         |$documentationReference.
+         |""".stripMargin
+    )
+
   val enterpriseSimulationSystemProperties = settingKey[Map[String, String]](
     s"""Provides additional system properties when starting a simulation, in addition to the ones which may already be defined for that simulation.
        |${systemPropertyDescription("gatling.enterprise.simulationSystemProperties")} with the format key1=value1,key2=value2

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -16,6 +16,8 @@
 
 package io.gatling.sbt.settings.gatling
 
+import java.{ lang => jl }
+
 import io.gatling.sbt.GatlingKeys._
 
 import sbt._
@@ -55,6 +57,7 @@ object EnterpriseSettings {
       config / enterprisePackageId := sys.props.get("gatling.enterprise.packageId").getOrElse(""),
       config / enterpriseTeamId := sys.props.get("gatling.enterprise.teamId").getOrElse(""),
       config / enterpriseSimulationId := sys.props.get("gatling.enterprise.simulationId").getOrElse(""),
+      config / waitForRunEnd := jl.Boolean.getBoolean("gatling.enterprise.waitForRunEnd"),
       config / enterpriseSimulationSystemProperties := Map.empty,
       config / enterpriseSimulationSystemPropertiesString := sys.props.get("gatling.enterprise.simulationSystemProperties").getOrElse(""),
       config / enterpriseSimulationEnvironmentVariables := Map.empty,

--- a/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/RecoverEnterprisePluginException.scala
@@ -66,17 +66,32 @@ class RecoverEnterprisePluginException(config: Configuration) {
       if (e.isCreated) {
         logCreatedSimulation(logger, e.getSimulation)
       }
-      logSimulationConfiguration(logger, e.getSimulation.id)
+      logSimulationConfiguration(logger, simulationIdSetting = None, waitForRunEndSetting = false, e.getSimulation.id)
       Failure(e.getCause)
   }
 
   protected def logCreatedSimulation(logger: ManagedLogger, simulation: Simulation): Unit =
     logger.info(s"Created simulation named ${simulation.name} with ID '${simulation.id}'")
 
-  protected def logSimulationConfiguration(logger: ManagedLogger, simulationId: UUID): Unit =
-    logger.info(
-      s"""To start again the same simulation, specify -Dgatling.enterprise.simulationId=$simulationId, or add the configuration to your SBT settings, e.g.:
-         |${config.id} / enterpriseSimulationId := "$simulationId"
-         |""".stripMargin
-    )
+  protected def logSimulationConfiguration(
+      logger: ManagedLogger,
+      simulationIdSetting: Option[UUID],
+      waitForRunEndSetting: Boolean,
+      simulationId: UUID
+  ): Unit = {
+    if (simulationIdSetting.isEmpty) {
+      logger.info(
+        s"""To start again the same simulation, specify -Dgatling.enterprise.simulationId=$simulationId, or add the configuration to your SBT settings, e.g.:
+           |${config.id} / enterpriseSimulationId := "$simulationId"
+           |""".stripMargin
+      )
+    }
+    if (!waitForRunEndSetting) {
+      logger.info(
+        s"""To wait for the end of the run when starting a simulation on Gatling Enterprise, specify -Dgatling.enterprise.waitForRunEnd=true, or add the configuration to your SBT settings, e.g.:
+           |${config.id} / waitForRunEnd := true
+           |""".stripMargin
+      )
+    }
+  }
 }


### PR DESCRIPTION
Modifications:

- Simplify how the 'enterpriseSimulationStart' input task works
- Add ability to wait for the end of a remote run on Gatling Enterprise

-----

Configuration example in the `build.sbt`:

```scala
Gatling / waitForRunEnd := true
```

or run with e.g. `sbt -Dgatling.enterprise.waitForRunEnd=true Gatling/enterpriseStart`