### PR TITLE
Update Scala to 2.13.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gatling-sbt   [![Build Status](https://travis-ci.org/gatling/gatling-sbt.svg?branch=master)](https://travis-ci.org/gatling/gatling-sbt)
+# gatling-sbt   [![Build Status](https://travis-ci.org/gatling/gatling-sbt-plugin.svg?branch=master)](https://travis-ci.org/gatling/gatling-sbt-plugin)
 
 ## /!\ The documentation has moved to [gatling.io](https://gatling.io) /!\
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ enablePlugins(BuildInfoPlugin, SbtPlugin, GatlingOssPlugin)
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 
 name := "gatling-sbt"
-scalaVersion := "2.12.17"
+scalaVersion := "2.13.10"
 sbtPlugin := true
 githubPath := "gatling/gatling-sbt-plugin"
 

--- a/src/sbt-test/gatling-sbt/copyConfigFiles/build.sbt
+++ b/src/sbt-test/gatling-sbt/copyConfigFiles/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GatlingPlugin)
 
-scalaVersion := "2.12.11"
+scalaVersion := "2.13.10"
 
 val gatlingVersion = "3.3.0"
 

--- a/src/sbt-test/gatling-sbt/enterpriseAssembly/build.sbt
+++ b/src/sbt-test/gatling-sbt/enterpriseAssembly/build.sbt
@@ -3,7 +3,7 @@ enablePlugins(GatlingPlugin)
 name := "my-test-project"
 version := "1.2.3"
 
-scalaVersion := "2.12.11"
+scalaVersion := "2.13.10"
 
 val gatlingVersion = "3.3.0"
 

--- a/src/sbt-test/gatling-sbt/runTests/build.sbt
+++ b/src/sbt-test/gatling-sbt/runTests/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GatlingPlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := "2.13.10"
 
 val gatlingVersion = "3.4.1"
 


### PR DESCRIPTION
My project is using Scala 2.13.10. It's having some build stability issues, which I think are stemming from the fact it relies on Gatling-SBT-Plugin which in turn relies on Scala 2.12.

I cloned this source, updated it to Scala 2.13.10, and was surprised to find that it worked with zero changes.

I found that there's already an earlier PR to do this same thing which was rejected without explanation. Is there some regression caused by this update that's not covered by the existing tests?

I also fixed your Travis links in the readme since it looks like they were pointing at an old URL.