### PR TITLE
feat: Manage private packages upload for Gatling Enterprise, closes HYB-253

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 libraryDependencies ++= Seq(
   "org.scalatest"     %% "scalatest"                         % "3.2.16" % Test,
   "org.zeroturnaround" % "zt-zip"                            % "1.15",
-  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.5.5"
+  "io.gatling"         % "gatling-enterprise-plugin-commons" % "1.6.0"
 )
 
 scriptedLaunchOpts := {

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -70,6 +70,12 @@ object GatlingKeys {
                           |$documentationReference.
                           |""".stripMargin)
 
+  val enterprisePrivateControlPlaneUrl =
+    settingKey[Option[URL]](s"""(optional) URL of a private control plane for Gatling Enterprise providing a private repository.
+                               |If this parameter is provided, packages will be registered as private packages and uploaded through this private control plane.
+                               |$documentationReference.
+                               |""".stripMargin)
+
   val waitForRunEnd =
     settingKey[Boolean](
       s"""Wait for the result after starting the simulation on Gatling Enterprise, and complete with an error if the simulation ends with any error status.

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseClient.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseClient.scala
@@ -28,6 +28,7 @@ object EnterpriseClient {
   def enterpriseClientTask(config: Configuration) = Def.task {
     val settingUrl = (config / enterpriseUrl).value
     val settingApiToken = (config / enterpriseApiToken).value
+    val settingPrivateControlPlaneUrl = (config / enterprisePrivateControlPlaneUrl).value
     val logger = streams.value.log
 
     if (settingApiToken.isEmpty) {
@@ -40,7 +41,7 @@ object EnterpriseClient {
     }
 
     try {
-      new HttpEnterpriseClient(settingUrl, settingApiToken, BuildInfo.name, BuildInfo.version)
+      new HttpEnterpriseClient(settingUrl, settingApiToken, BuildInfo.name, BuildInfo.version, settingPrivateControlPlaneUrl.orNull)
     } catch {
       case _: UnsupportedClientException =>
         logger.error(

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -57,6 +57,9 @@ object EnterpriseSettings {
       config / enterprisePackageId := sys.props.get("gatling.enterprise.packageId").getOrElse(""),
       config / enterpriseTeamId := sys.props.get("gatling.enterprise.teamId").getOrElse(""),
       config / enterpriseSimulationId := sys.props.get("gatling.enterprise.simulationId").getOrElse(""),
+      config / enterprisePrivateControlPlaneUrl := sys.props
+        .get("gatling.enterprise.privateControlPlaneUrl")
+        .map(configString => new URL(configString)),
       config / waitForRunEnd := jl.Boolean.getBoolean("gatling.enterprise.waitForRunEnd"),
       config / enterpriseSimulationSystemProperties := Map.empty,
       config / enterpriseSimulationSystemPropertiesString := sys.props.get("gatling.enterprise.simulationSystemProperties").getOrElse(""),


### PR DESCRIPTION
Motivation:
- Gatling Enterprise has a new private packages feature allowing users to host their simulation packages.
- Private packages are uploaded through a Gatling control plane, hosted by the user, presenting a dedicated route.

Modifications:
- Bump gatling-enterprise-plugin-commons version to 1.6.0
- Manage a new settings optional key `gatlingPrivateControlPlaneUrl`.
- If this URL is configured, newly created packages and uploaded ones are considered as private.
- Private packages are uploaded through configured private control plane.

Result:
- Users can configure a private control plane and use it to host private packages.

Ref: HYB-253