### PR TITLE
chore: remove "private" prefix from control plane config

### DIFF
--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -70,8 +70,8 @@ object GatlingKeys {
                           |$documentationReference.
                           |""".stripMargin)
 
-  val enterprisePrivateControlPlaneUrl =
-    settingKey[Option[URL]](s"""(optional) URL of a private control plane for Gatling Enterprise providing a private repository.
+  val enterpriseControlPlaneUrl =
+    settingKey[Option[URL]](s"""(optional) URL of a control plane for Gatling Enterprise providing a private repository.
                                |If this parameter is provided, packages will be registered as private packages and uploaded through this private control plane.
                                |$documentationReference.
                                |""".stripMargin)

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseClient.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseClient.scala
@@ -28,7 +28,7 @@ object EnterpriseClient {
   def enterpriseClientTask(config: Configuration) = Def.task {
     val settingUrl = (config / enterpriseUrl).value
     val settingApiToken = (config / enterpriseApiToken).value
-    val settingPrivateControlPlaneUrl = (config / enterprisePrivateControlPlaneUrl).value
+    val settingControlPlaneUrl = (config / enterpriseControlPlaneUrl).value
     val logger = streams.value.log
 
     if (settingApiToken.isEmpty) {
@@ -41,7 +41,7 @@ object EnterpriseClient {
     }
 
     try {
-      new HttpEnterpriseClient(settingUrl, settingApiToken, BuildInfo.name, BuildInfo.version, settingPrivateControlPlaneUrl.orNull)
+      new HttpEnterpriseClient(settingUrl, settingApiToken, BuildInfo.name, BuildInfo.version, settingControlPlaneUrl.orNull)
     } catch {
       case _: UnsupportedClientException =>
         logger.error(

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -57,8 +57,8 @@ object EnterpriseSettings {
       config / enterprisePackageId := sys.props.get("gatling.enterprise.packageId").getOrElse(""),
       config / enterpriseTeamId := sys.props.get("gatling.enterprise.teamId").getOrElse(""),
       config / enterpriseSimulationId := sys.props.get("gatling.enterprise.simulationId").getOrElse(""),
-      config / enterprisePrivateControlPlaneUrl := sys.props
-        .get("gatling.enterprise.privateControlPlaneUrl")
+      config / enterpriseControlPlaneUrl := sys.props
+        .get("gatling.enterprise.controlPlaneUrl")
         .map(configString => new URL(configString)),
       config / waitForRunEnd := jl.Boolean.getBoolean("gatling.enterprise.waitForRunEnd"),
       config / enterpriseSimulationSystemProperties := Map.empty,


### PR DESCRIPTION
Motivation:
Our users doesn't know about private or public control plane.

Modifications:
Remove private prefix on configuration.