### PR TITLE
feat: load and resolve config file in enterpriseUpload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ githubPath := "gatling/gatling-sbt-plugin"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"                         % "3.2.17" % Test,
-  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.9.0-M5"
+  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.9.0-M7"
 )
 
 scriptedLaunchOpts := {


### PR DESCRIPTION
Motivation:
Make Gatling as Code accessible to sbt plugin user

Modifications:
Retrieve packageId from json config file if exists, and fallback to configured package id.

Ref: MISC-447