### PR TITLE
chore: drop beta package descriptor feature, closes HYB-545

### DIFF
--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
@@ -20,12 +20,11 @@ import java.util.UUID
 
 import scala.util.Try
 
-import io.gatling.plugin.configuration.PackageConfiguration
 import io.gatling.sbt.GatlingKeys._
 import io.gatling.sbt.settings.gatling.EnterpriseUtils._
 
 import sbt._
-import sbt.Keys.{ baseDirectory, streams }
+import sbt.Keys.streams
 
 class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterprisePackage) extends RecoverEnterprisePluginException(config) {
   val uploadEnterprisePackage: InitializeTask[Unit] = Def.task {
@@ -36,15 +35,7 @@ class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterpr
     val enterprisePlugin = EnterprisePluginTask.batchEnterprisePluginTask(config).value
 
     Try {
-      val packageId = Option(PackageConfiguration.loadToJson(baseDirectory.value))
-        .map { jsonConfig =>
-          logger.info("Package configuration file detected, applying it.")
-          val id = enterprisePlugin.uploadPackageConfiguration(jsonConfig).toString
-          logger.info(s"Package id: $id")
-          id
-        }
-        .getOrElse(settingPackageId)
-      if (packageId.isEmpty && settingSimulationId.isEmpty) {
+      if (settingPackageId.isEmpty && settingSimulationId.isEmpty) {
         logger.error(
           s"""A package ID is required to upload a package on Gatling Enterprise; see https://gatling.io/docs/enterprise/cloud/reference/user/package_conf/ , create a package and copy its ID.
              |You can then set your package ID value by passing it with -Dgatling.enterprise.packageId=<packageId>, or add the configuration to your SBT settings, e.g.:
@@ -56,8 +47,8 @@ class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterpr
         throw ErrorAlreadyLoggedException
       }
 
-      if (packageId.nonEmpty) {
-        val packageUUID = UUID.fromString(packageId)
+      if (settingPackageId.nonEmpty) {
+        val packageUUID = UUID.fromString(settingPackageId)
         enterprisePlugin.uploadPackage(packageUUID, file)
       } else {
         val simulationId = UUID.fromString(settingSimulationId)


### PR DESCRIPTION
Motivation:
- Package Descriptor feature is going out of beta and v1 is coming

Modifications:
- Remove beta package descriptor deployment call from enterpriseUpload target

Result:
- Beta package descriptor: out