### PR TITLE
chore: handle simulation validation ID on deploy command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ sbtPluginPublishLegacyMavenStyle := false
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"                         % "3.2.19" % Test,
-  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.16.3",
+  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.17.0+1-a8066dc9-SNAPSHOT",
   "io.gatling"     % "gatling-shared-cli"                % "0.0.6"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ sbtPluginPublishLegacyMavenStyle := false
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"                         % "3.2.19" % Test,
-  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.17.0+1-a8066dc9-SNAPSHOT",
+  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.17.1",
   "io.gatling"     % "gatling-shared-cli"                % "0.0.6"
 )
 

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -56,6 +56,10 @@ object GatlingKeys {
 
   @deprecated
   val enterpriseSimulationId = settingKey[String]("Deprecated simulation ID setting")
+
+  val enterpriseValidateSimulationId =
+    settingKey[String](s"""Simulation ID on Gatling Enterprise. Used by `enterpriseDeploy` to validate a simulation ID was part of the deployment.
+                          |${systemPropertyDescription(ConfigurationConstants.DeployOptions.ValidateSimulationId.SYS_PROP)}.
                           |$documentationReference.
                           |""".stripMargin)
 

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -51,14 +51,11 @@ object GatlingKeys {
          |""".stripMargin
     )
 
-  val enterprisePackageId = settingKey[String](s"""Package ID on Gatling Enterprise (used by `enterpriseUpload` task).
-                                                  |${systemPropertyDescription(ConfigurationConstants.UploadOptions.PackageId.SYS_PROP)}.
-                                                  |$documentationReference.
-                                                  |""".stripMargin)
+  @deprecated
+  val enterprisePackageId = settingKey[String]("Deprecated package ID setting")
 
-  val enterpriseSimulationId =
-    settingKey[String](s"""Simulation ID on Gatling Enterprise. Used by `enterprisePackage` if `enterprisePackageId` isn't configured.
-                          |${systemPropertyDescription(ConfigurationConstants.UploadOptions.SimulationId.SYS_PROP)}.
+  @deprecated
+  val enterpriseSimulationId = settingKey[String]("Deprecated simulation ID setting")
                           |$documentationReference.
                           |""".stripMargin)
 
@@ -81,10 +78,10 @@ object GatlingKeys {
                                            |$documentationReference.
                                            |""".stripMargin)
 
+  @deprecated
   val enterpriseUpload = taskKey[Unit](
-    s"""Upload a package for Gatling Enterprise. Require `enterpriseApiToken` and either `enterprisePackageId` or `enterpriseSimulationId` to be configured.
-       |$documentationReference.
-       |""".stripMargin
+    "The enterprise upload command is no longer supported. It has been replaced by the enterprise deploy command." +
+      " Refer to the documentation for more information: https://docs.gatling.io/reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise"
   )
 
   val enterpriseDeploy = inputKey[Unit]("Deploy a package and configured simulations")

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -58,6 +58,7 @@ object EnterpriseSettings {
       config / enterpriseUpload := taskUpload.uploadEnterprisePackage.value,
       config / enterpriseDeploy := taskDeploy.enterpriseDeploy.evaluated,
       config / enterpriseStart := taskStart.enterpriseSimulationStart.evaluated,
+      config / enterpriseValidateSimulationId := Option(ConfigurationConstants.DeployOptions.ValidateSimulationId.value()).getOrElse(""),
       config / enterpriseControlPlaneUrl := Option(ConfigurationConstants.ControlPlaneUrl.value())
         .map(configString => new URI(configString).toURL),
       config / waitForRunEnd := ConfigurationConstants.StartOptions.WaitForRunEnd.value(),

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -47,7 +47,7 @@ object EnterpriseSettings {
 
   def settings(config: Configuration) = {
     val taskPackage = new TaskEnterprisePackage(config)
-    val taskUpload = new TaskEnterpriseUpload(config, taskPackage)
+    val taskUpload = new TaskEnterpriseUpload(config)
     val taskDeploy = new TaskEnterpriseDeploy(config, taskPackage)
     val taskStart = new TaskEnterpriseStart(config, taskDeploy)
 
@@ -58,8 +58,6 @@ object EnterpriseSettings {
       config / enterpriseUpload := taskUpload.uploadEnterprisePackage.value,
       config / enterpriseDeploy := taskDeploy.enterpriseDeploy.evaluated,
       config / enterpriseStart := taskStart.enterpriseSimulationStart.evaluated,
-      config / enterprisePackageId := Option(ConfigurationConstants.UploadOptions.PackageId.value()).getOrElse(""),
-      config / enterpriseSimulationId := Option(ConfigurationConstants.UploadOptions.SimulationId.value()).getOrElse(""),
       config / enterpriseControlPlaneUrl := Option(ConfigurationConstants.ControlPlaneUrl.value())
         .map(configString => new URI(configString).toURL),
       config / waitForRunEnd := ConfigurationConstants.StartOptions.WaitForRunEnd.value(),

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseDeploy.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseDeploy.scala
@@ -64,14 +64,26 @@ class TaskEnterpriseDeploy(config: Configuration, enterprisePackage: TaskEnterpr
     val descriptorFile = DeploymentConfiguration.fromBaseDirectory((config / baseDirectory).value, customFileName.orNull)
     val artifactId = (config / name).value
     val controlPlaneUrl = (config / enterpriseControlPlaneUrl).value
+    val validateSimulationId = (config / enterpriseValidateSimulationId).value
 
     Try {
-      enterprisePlugin.deployFromDescriptor(
-        descriptorFile,
-        packageFile,
-        artifactId,
-        controlPlaneUrl.isDefined
-      )
+      if (validateSimulationId.isEmpty) {
+        enterprisePlugin.deployFromDescriptor(
+          descriptorFile,
+          packageFile,
+          artifactId,
+          controlPlaneUrl.isDefined
+        )
+      } else {
+        enterprisePlugin.deployFromDescriptor(
+          descriptorFile,
+          packageFile,
+          artifactId,
+          controlPlaneUrl.isDefined,
+          validateSimulationId
+        )
+      }
+
     }.recoverWith(recoverEnterprisePluginException(logger)).get
   }
 }

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseUpload.scala
@@ -16,47 +16,15 @@
 
 package io.gatling.sbt.settings.gatling
 
-import java.util.UUID
-
-import scala.util.Try
-
-import io.gatling.plugin.ConfigurationConstants
-import io.gatling.sbt.GatlingKeys._
 import io.gatling.sbt.settings.gatling.EnterpriseUtils._
 
 import sbt._
-import sbt.Keys.streams
 
-class TaskEnterpriseUpload(config: Configuration, enterprisePackage: TaskEnterprisePackage) extends RecoverEnterprisePluginException(config) {
+class TaskEnterpriseUpload(config: Configuration) extends RecoverEnterprisePluginException(config) {
   val uploadEnterprisePackage: InitializeTask[Unit] = Def.task {
-    val logger = streams.value.log
-    val file = enterprisePackage.buildEnterprisePackage.value
-    val settingPackageId = (config / enterprisePackageId).value
-    val settingSimulationId = (config / enterpriseSimulationId).value
-    val enterprisePlugin = EnterprisePluginTask.batchEnterprisePluginTask(config).value
-
-    Try {
-      if (settingPackageId.isEmpty && settingSimulationId.isEmpty) {
-        logger.error(
-          s"""A package ID is required to upload a package on Gatling Enterprise; see https://docs.gatling.io/reference/execute/cloud/user/package-conf/ , create a package and copy its ID.
-             |You can then set your package ID value by passing it with -D${ConfigurationConstants.UploadOptions.PackageId.SYS_PROP}=<packageId>, or add the configuration to your SBT settings, e.g.:
-             |${config.id} / enterprisePackageId := MY_PACKAGE_ID
-             |
-             |Alternately, if you don't configure a packageId, you can configure the simulationId of an existing simulation on Gatling Enterprise: your code will be uploaded to the package used by that simulation.
-             |""".stripMargin
-        )
-        throw ErrorAlreadyLoggedException
-      }
-
-      if (settingPackageId.nonEmpty) {
-        val packageUUID = UUID.fromString(settingPackageId)
-        enterprisePlugin.uploadPackage(packageUUID, file)
-      } else {
-        val simulationId = UUID.fromString(settingSimulationId)
-        enterprisePlugin.uploadPackageWithSimulationId(simulationId, file)
-      }
-
-      logger.success("Successfully upload package")
-    }.recoverWith(recoverEnterprisePluginException(logger)).get
+    throw new NotImplementedError(
+      "The enterprise upload command is no longer supported. It has been replaced by the enterprise deploy command." +
+        " Refer to the documentation for more information: https://docs.gatling.io/reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise"
+    )
   }
 }


### PR DESCRIPTION
[chore: drop enterprise upload command with expressive message](https://github.com/gatling/gatling-sbt-plugin/commit/cce185f8d969625a85925ec71787925beb576a76)

**Motivation:**
Command is replaced by enterprise deploy.

**Modification:**
Drop command support, when command is called an error message redirect to deploy command documentation.

[chore: handle simulation validation ID on deploy command](https://github.com/gatling/gatling-sbt-plugin/commit/5d0aa3778078e4836879ea08090e92b6095b17b9)

**Motivation:**
Validate a given simulation ID have been deployed.