### PR TITLE
chore: update gatling-enterprise-plugin-commons to 1.20.3, closes MIS…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ sbtPluginPublishLegacyMavenStyle := false
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"                         % "3.2.19" % Test,
-  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.20.2",
+  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.20.3",
   "io.gatling"     % "gatling-shared-cli"                % "0.0.7"
 )
 


### PR DESCRIPTION
…C-606

 Motivation:
New dedicated endpoint is used in new enterprise common plugin version.

Modifications:
Update gatling-enterprise-plugin-commons version

Result:
Up-to-date sbt plugin.