### PR TITLE
Cross-build and publish for sbt 1 and sbt 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,4 @@ jobs:
 
       - name: Test
         run: |
-          sbt \
-            "+headerCheck" \
-            "all scalafmtSbtCheck scalafmtCheckAll" \
-            "scalafixAll --check" \
-            "+test" \
-            "+scripted"
+          sbt "+headerCheck; all scalafmtSbtCheck scalafmtCheckAll; scalafixAll --check; +test; +scripted"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Test
         run: |
           sbt \
-            "all headerCheck scalafmtSbtCheck scalafmtCheckAll" \
+            "+headerCheck" \
+            "all scalafmtSbtCheck scalafmtCheckAll" \
             "scalafixAll --check" \
-            "test" \
-            "scripted"
+            "+test" \
+            "+scripted"

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,37 @@ enablePlugins(BuildInfoPlugin, SbtPlugin, GatlingOssPlugin)
 
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 
+// Scala 2.12 builds the plugin for sbt 1.x, Scala 3 builds it for sbt 2.x.
+// sbt 2.0.x is built with Scala 3.8.4, and the plugin must use that exact version so it can read sbt's TASTy.
+val scala212 = "2.12.21"
+val scala3 = "3.8.4"
+
 name := "gatling-sbt"
-scalaVersion := "2.12.21"
+scalaVersion := scala212
+crossScalaVersions := Seq(scala212, scala3)
 sbtPlugin := true
 githubPath := "gatling/gatling-sbt-plugin"
 sbtPluginPublishLegacyMavenStyle := false
+
+// GatlingPublishPlugin sets `crossPaths := false`, which disables sbt's automatic `scala-<version>` source
+// directories. We add them back explicitly so sbt-1-only (Scala 2.12) and sbt-2-only (Scala 3) sources can
+// coexist: `src/main/scala-2.12` for sbt 1.x and `src/main/scala-3` for sbt 2.x.
+Compile / unmanagedSourceDirectories += {
+  val base = (Compile / sourceDirectory).value
+  scalaBinaryVersion.value match {
+    case "2.12" => base / "scala-2.12"
+    case _      => base / "scala-3"
+  }
+}
+
+// sbt 1.x supports JDK 8+, so the Scala 2.12 build targets Java 11; sbt 2.x requires JDK 17+, and Scala 3
+// on recent JDKs no longer accepts `-release 11`, so the Scala 3 build targets Java 17.
+gatlingCompilerRelease := {
+  scalaBinaryVersion.value match {
+    case "2.12" => 11
+    case _      => 17
+  }
+}
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"                         % "3.2.20" % Test,
@@ -25,7 +51,12 @@ scriptedLaunchOpts := {
 
 scriptedBufferLog := false
 
-pluginCrossBuild / sbtVersion := "1.11.7"
+pluginCrossBuild / sbtVersion := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.12.13"
+    case _      => "2.0.2"
+  }
+}
 gatlingDevelopers := Seq(
   GatlingDeveloper(
     "slandelle@gatling.io",

--- a/src/main/scala-2.12/io/gatling/sbt/Compat.scala
+++ b/src/main/scala-2.12/io/gatling/sbt/Compat.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2011-2026 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.sbt
+
+import java.io.File
+
+import scala.annotation.nowarn
+
+import sbt._
+import xsbti.FileConverter
+
+/**
+ * sbt 1.x implementations of the few APIs that differ between sbt 1.x and sbt 2.x. The sbt 2.x counterparts live under `src/main/scala-3`, so that the rest of
+ * the plugin's sources can be shared between both sbt versions.
+ */
+private[gatling] object Compat {
+
+  /**
+   * The built-in `IntegrationTest` configuration. It was removed in sbt 2.x, where [[Compat]] recreates an equivalent one.
+   */
+  @nowarn("cat=deprecation")
+  val IntegrationTest: Configuration = sbt.IntegrationTest
+
+  /**
+   * Settings enabling the `IntegrationTest` (`it`) configuration, i.e. compiling and running sources found in `src/it`.
+   */
+  @nowarn("cat=deprecation")
+  val integrationTestSettings: Seq[Def.Setting[?]] = sbt.Defaults.itSettings
+
+  /**
+   * Resolves the actual files backing a classpath. On sbt 1.x each classpath entry already carries a plain [[java.io.File]].
+   */
+  def toFiles(classpath: Def.Classpath, converter: FileConverter): Seq[File] =
+    classpath.map(_.data)
+
+  /**
+   * The project's own compiled class directories, used to scan for simulations. On sbt 1.x they appear directly in the classpath as directories, so we keep the
+   * historical behaviour of filtering the full classpath (which also captures inter-project class directories).
+   */
+  def classesDirectories(fullClasspath: Def.Classpath, classDirectories: Seq[File], converter: FileConverter): Seq[File] =
+    toFiles(fullClasspath, converter).filter(_.isDirectory)
+
+  /**
+   * The internal (inter-project) dependencies to package as extra library jars, with their module IDs. On sbt 1.x internal dependencies usually appear on the
+   * classpath as class directories and are already packaged through [[classesDirectories]], so only jar entries (`exportJars := true`) are returned here.
+   */
+  def internalDependencies(internalDependencyClasspath: Def.Classpath, converter: FileConverter): Seq[(ModuleID, File)] =
+    internalDependencyClasspath
+      .filter(_.data.isFile)
+      .flatMap(entry => entry.get(Keys.moduleID.key).map(_ -> entry.data))
+
+  /**
+   * Adapts the file produced for the `packageBin` task to the value type that key expects. On sbt 1.x it is a plain [[java.io.File]].
+   */
+  def toPackagedArtifact(file: File, converter: FileConverter): File =
+    file
+
+  /**
+   * Opts a task out of sbt 2.x's on-disk task caching, which rejects [[java.io.File]] results and requires a `JsonFormat` for other results. sbt 1.x has no
+   * such caching, so this is the identity.
+   */
+  def uncached[A](task: A): A =
+    task
+}

--- a/src/main/scala-3/io/gatling/sbt/Compat.scala
+++ b/src/main/scala-3/io/gatling/sbt/Compat.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2011-2026 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.sbt
+
+import java.io.File
+
+import sbt.*
+import sbt.plugins.JUnitXmlReportPlugin.autoImport.testReportSettings
+import xsbti.{ FileConverter, HashedVirtualFileRef }
+
+/**
+ * sbt 2.x implementations of the few APIs that differ between sbt 1.x and sbt 2.x. The sbt 1.x counterparts live under `src/main/scala-2.12`, so that the
+ * rest of the plugin's sources can be shared between both sbt versions.
+ */
+private[gatling] object Compat {
+
+  /**
+   * The built-in `IntegrationTest` configuration was removed in sbt 2.x, so we recreate the exact one sbt 1.x used to provide: id `IntegrationTest`,
+   * Ivy name `it`, extending `Runtime`. Keeping the same id and name preserves how it is referenced on the command line (`IntegrationTest / ...` and
+   * `It / ...`) and where its sources (`src/it`) and reports (`target/it-reports`) live.
+   */
+  val IntegrationTest: Configuration = Configuration.of("IntegrationTest", "it").extend(Runtime)
+
+  /**
+   * Settings enabling the `IntegrationTest` (`it`) configuration, i.e. compiling and running sources found in `src/it`. This mirrors what sbt 1.x's
+   * `Defaults.itSettings` used to provide. On sbt 2.x the built-in `JUnitXmlReportPlugin` only wires the JUnit XML report listener into `Test` (the
+   * `IntegrationTest` configuration it used to also cover no longer exists), so we add `testReportSettings` here to keep generating `target/it-reports`.
+   */
+  val integrationTestSettings: Seq[Def.Setting[?]] =
+    inConfig(IntegrationTest)(Defaults.testSettings ++ testReportSettings)
+
+  /**
+   * Resolves the actual files backing a classpath. On sbt 2.x each classpath entry carries a virtual file reference that must be resolved through the
+   * build's [[xsbti.FileConverter]].
+   */
+  def toFiles(classpath: Def.Classpath, converter: FileConverter): Seq[File] =
+    classpath.map(entry => converter.toPath(entry.data).toFile)
+
+  /**
+   * The project's compiled class directories, used to scan for simulations. On sbt 2.x the classpath usually carries packaged jars rather than class
+   * directories, so we use the `classDirectory` locations directly (compilation is triggered by evaluating `fullClasspath` at the call site). Directory
+   * entries still found on the classpath (`exportJars := false`) are included as well, mirroring the sbt 1.x behaviour.
+   */
+  def classesDirectories(fullClasspath: Def.Classpath, classDirectories: Seq[File], converter: FileConverter): Seq[File] =
+    (classDirectories ++ toFiles(fullClasspath, converter)).filter(_.isDirectory).distinct
+
+  /**
+   * The internal (inter-project) dependencies to package as extra library jars, with their module IDs. On sbt 2.x internal dependencies appear on the
+   * classpath as packaged jars carrying their module ID as a string attribute.
+   */
+  def internalDependencies(internalDependencyClasspath: Def.Classpath, converter: FileConverter): Seq[(ModuleID, File)] =
+    internalDependencyClasspath
+      .flatMap { entry =>
+        entry.get(Keys.moduleIDStr).map { str =>
+          Classpaths.moduleIdJsonKeyFormat.read(str) -> converter.toPath(entry.data).toFile
+        }
+      }
+      .filter { case (_, file) => file.isFile }
+
+  /**
+   * Adapts the file produced for the `packageBin` task to the value type that key expects. On sbt 2.x it is a virtual file reference resolved through
+   * the build's [[xsbti.FileConverter]].
+   */
+  def toPackagedArtifact(file: File, converter: FileConverter): HashedVirtualFileRef =
+    converter.toVirtualFile(file.toPath)
+
+  /**
+   * Opts a task out of sbt 2.x's on-disk task caching, which rejects [[java.io.File]] results and requires a `JsonFormat` for other results. Delegates
+   * to sbt 2.x's `Def.uncached` marker.
+   */
+  inline def uncached[A](inline task: A): A =
+    Def.uncached(task)
+}

--- a/src/main/scala/io/gatling/sbt/GatlingKeys.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingKeys.scala
@@ -25,7 +25,7 @@ import sbt._
 object GatlingKeys {
   // Configurations
   val Gatling = config("gatling") extend Test
-  val GatlingIt = config("gatling-it") extend IntegrationTest
+  val GatlingIt = config("gatling-it") extend Compat.IntegrationTest
 
   // OSS Tasks
   val startRecorder = inputKey[Unit]("Start Gatling's Recorder")

--- a/src/main/scala/io/gatling/sbt/GatlingPlugin.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingPlugin.scala
@@ -27,7 +27,7 @@ object GatlingPlugin extends AutoPlugin {
   val autoImport: GatlingKeys.type = GatlingKeys
   import autoImport._
 
-  override def projectConfigurations: Seq[Configuration] = Seq(Gatling, GatlingIt, IntegrationTest)
+  override def projectConfigurations: Seq[Configuration] = Seq(Gatling, GatlingIt, Compat.IntegrationTest)
   override def projectSettings: Seq[Def.Setting[?]] = gatlingSettings ++ gatlingItSettings ++ ProjectSettings.projectSettings
 
   // Test framework definition
@@ -37,15 +37,15 @@ object GatlingPlugin extends AutoPlugin {
   lazy val gatlingSettings: Seq[Def.Setting[?]] =
     inConfig(Gatling)(
       Defaults.testTasks ++
-        (forkOptions := Defaults.forkOptionsTask.value) ++
+        (forkOptions := Compat.uncached(Defaults.forkOptionsTask.value)) ++
         BaseSettings.settings(Gatling, Test)
     ) ++ ProjectBaseSettings.settings(Gatling)
 
   lazy val gatlingItSettings: Seq[Def.Setting[?]] =
     inConfig(GatlingIt)(
-      Defaults.itSettings ++
+      Compat.integrationTestSettings ++
         Defaults.testTasks ++
-        (forkOptions := Defaults.forkOptionsTask.value) ++
-        BaseSettings.settings(GatlingIt, IntegrationTest)
+        (forkOptions := Compat.uncached(Defaults.forkOptionsTask.value)) ++
+        BaseSettings.settings(GatlingIt, Compat.IntegrationTest)
     ) ++ ProjectBaseSettings.settings(GatlingIt)
 }

--- a/src/main/scala/io/gatling/sbt/settings/BaseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/BaseSettings.scala
@@ -20,6 +20,7 @@ import scala.jdk.CollectionConverters._
 
 import io.gatling.plugin.GatlingConstants
 import io.gatling.plugin.util.SystemProperties
+import io.gatling.sbt.Compat
 import io.gatling.sbt.GatlingPlugin.gatlingTestFramework
 import io.gatling.sbt.settings.gatling._
 
@@ -58,6 +59,6 @@ object BaseSettings {
     config / javaOptions ++= overrideDefaultJavaOptions(),
     config / parallelExecution := false,
     config / fork := true,
-    config / testGrouping := (config / testGrouping).value flatMap singleTestGroup
+    config / testGrouping := Compat.uncached((config / testGrouping).value flatMap singleTestGroup)
   ) ++ OssSettings.settings(config, parent) ++ EnterpriseSettings.settings(config)
 }

--- a/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/EnterpriseSettings.scala
@@ -19,6 +19,7 @@ package io.gatling.sbt.settings.gatling
 import java.net.URI
 
 import io.gatling.plugin.ConfigurationConstants
+import io.gatling.sbt.Compat
 import io.gatling.sbt.GatlingKeys._
 
 import sbt._
@@ -26,7 +27,7 @@ import sbt.Keys._
 
 object EnterpriseSettings {
   private val onLoadBreakIfLegacyPluginFound = Def.setting {
-    (onLoad in Global).value.andThen { state =>
+    (Global / onLoad).value.andThen { state =>
       val foundLegacyFrontLinePlugin =
         Project.extract(state).structure.units.exists { case (_, build) =>
           build.projects.exists(
@@ -54,7 +55,7 @@ object EnterpriseSettings {
     Seq(
       config / enterpriseApiUrl := new URI(ConfigurationConstants.ApiUrl.value()).toURL,
       config / enterpriseWebAppUrl := new URI(ConfigurationConstants.WebAppUrl.value()).toURL,
-      config / enterprisePackage := taskPackage.buildEnterprisePackage.value,
+      config / enterprisePackage := Compat.uncached(taskPackage.buildEnterprisePackage.value),
       config / enterpriseUpload := taskUpload.uploadEnterprisePackage.value,
       config / enterpriseDeploy := taskDeploy.enterpriseDeploy.evaluated,
       config / enterpriseStart := taskStart.enterpriseSimulationStart.evaluated,
@@ -63,18 +64,20 @@ object EnterpriseSettings {
         .map(configString => new URI(configString).toURL),
       config / waitForRunEnd := ConfigurationConstants.StartOptions.WaitForRunEnd.value(),
       config / enterpriseApiToken := Option(ConfigurationConstants.ApiToken.value()).getOrElse(""),
-      config / packageBin := (config / enterprisePackage).value // If we directly use config / enterprisePackage for publishing, classifiers (-tests or -it) are not correctly handled.
+      config / packageBin := Compat.uncached(
+        Compat.toPackagedArtifact((config / enterprisePackage).value, fileConverter.value)
+      ) // If we directly use config / enterprisePackage for publishing, classifiers (-tests or -it) are not correctly handled.
     )
   }
 
   private def legacyAssemblySetting(config: Configuration) = {
     val taskPackage = new TaskEnterprisePackage(config)
-    config / assembly := taskPackage.legacyPackageEnterpriseJar.value
+    config / assembly := Compat.uncached(taskPackage.legacyPackageEnterpriseJar.value)
   }
 
   private val breakIfLegacyPluginFoundSetting =
     Global / onLoad := onLoadBreakIfLegacyPluginFound.value
 
   lazy val projectSettings: Seq[Def.Setting[?]] =
-    Seq(legacyAssemblySetting(Test), legacyAssemblySetting(IntegrationTest), breakIfLegacyPluginFoundSetting)
+    Seq(legacyAssemblySetting(Test), legacyAssemblySetting(Compat.IntegrationTest), breakIfLegacyPluginFoundSetting)
 }

--- a/src/main/scala/io/gatling/sbt/settings/gatling/OssSettings.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/OssSettings.scala
@@ -21,6 +21,7 @@ import java.io.File
 import scala.jdk.CollectionConverters._
 
 import io.gatling.plugin.GatlingConstants
+import io.gatling.sbt.Compat
 import io.gatling.sbt.GatlingKeys._
 import io.gatling.sbt.utils.ReportUtils._
 import io.gatling.sbt.utils.StartRecorderUtils.{ addPackageIfNecessary, optionsParser, toShortOptionAndValue }
@@ -41,7 +42,7 @@ object OssSettings {
     val allArgs = addPackageIfNecessary(args ++ simulationsFolderArg ++ resourcesFolderArg ++ formatArg, organization.value)
 
     val fork = new Fork("java", Some("io.gatling.recorder.GatlingRecorder"))
-    val classpathElements = (parent / dependencyClasspath).value.map(_.data) :+ (config / resourceDirectory).value
+    val classpathElements = Compat.toFiles((parent / dependencyClasspath).value, fileConverter.value) :+ (config / resourceDirectory).value
     val classpath = buildClassPathArgument(classpathElements)
     fork(forkOptionsWithRunJVMOptions(classpath), allArgs)
   }
@@ -55,7 +56,7 @@ object OssSettings {
     reportsPaths.headOption.foreach { folderName =>
       val opts = toShortOptionAndValue("ro" -> folderName) ++ toShortOptionAndValue("rf" -> (config / target).value.getPath)
       val fork = new Fork("java", Some("io.gatling.app.Gatling"))
-      val classpathElements = (parent / dependencyClasspath).value.map(_.data) :+ (config / resourceDirectory).value
+      val classpathElements = Compat.toFiles((parent / dependencyClasspath).value, fileConverter.value) :+ (config / resourceDirectory).value
       val classpath = buildClassPathArgument(classpathElements)
       fork(forkOptionsWithRunJVMOptions(classpath ++ GatlingConstants.DEFAULT_JVM_OPTIONS_GATLING.asScala), opts)
     }
@@ -65,7 +66,7 @@ object OssSettings {
     Seq("-cp", classPathElements.mkString(File.pathSeparator))
 
   private def stateBasedParser[T, U](inputSource: SettingKey[T])(parserMaker: T => U) =
-    Def.setting { state: State =>
+    Def.setting { (state: State) =>
       val extracted = Project.extract(state)
       val input = extracted.get(inputSource)
       parserMaker(input)
@@ -73,7 +74,9 @@ object OssSettings {
 
   def settings(config: Configuration, parent: Configuration) = Seq(
     config / startRecorder := recorderRunner(config, parent).evaluated,
-    config / clean := cleanReports((config / target).value),
+    // `clean` deletes report folders as a side effect and must not be memoised by sbt 2.x's task cache
+    // (otherwise a second config's clean can reuse the first's cached result and skip the deletion).
+    config / clean := Compat.uncached(cleanReports((config / target).value)),
     config / generateReport := generateGatlingReport(config, parent).evaluated
   )
 }

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
@@ -20,11 +20,12 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
-import io.gatling.plugin.pkg.EnterprisePackager
+import io.gatling.plugin.pkg.{ Dependency, EnterprisePackager }
+import io.gatling.sbt.Compat
 import io.gatling.sbt.settings.gatling.EnterpriseUtils.InitializeTask
 import io.gatling.sbt.utils._
 
-import sbt.{ Configuration, Def, IntegrationTest, ModuleDescriptorConfiguration, Test, _ }
+import sbt.{ Configuration, Def, ModuleDescriptorConfiguration, Test, _ }
 import sbt.Keys._
 
 object TaskEnterprisePackage {
@@ -54,11 +55,33 @@ class TaskEnterprisePackage(config: Configuration) {
       moduleDescriptor
     )
 
-    val classesDirectories = (config / fullClasspath).value.map(_.data).filter(_.isDirectory)
+    // The compiled simulations live in the project's own class directories. On sbt 1.x these appear in the
+    // classpath as directories; on sbt 2.x the classpath instead carries packaged jars, so we get the class
+    // directories from `classDirectory`. Evaluating `fullClasspath` triggers compilation on both versions.
+    val classesDirectories = Compat.classesDirectories(
+      (config / fullClasspath).value,
+      Seq((config / classDirectory).value, (Compile / classDirectory).value),
+      fileConverter.value
+    )
 
     val pluginLogger = EnterprisePluginIO.enterprisePluginLoggerTask.value
 
     val rootModule = moduleDescriptor.module
+
+    // Internal (inter-project) dependencies exported as jars are packaged as extra library jars, like the
+    // Maven and Gradle plugins do (`DependenciesAnalyzer` only sees external modules, and on sbt 2.x internal
+    // dependencies no longer appear on the classpath as class directories). The project's own products are
+    // excluded: their classes are already packaged through `classesDirectories`.
+    val internalDependencies = Compat
+      .internalDependencies((config / internalDependencyClasspath).value, fileConverter.value)
+      .collect {
+        case (moduleId, jar) if moduleId.organization != rootModule.organization || moduleId.name != rootModule.name =>
+          new Dependency(
+            new Dependency.Id(moduleId.organization, moduleId.name, moduleId.revision, null),
+            jar
+          )
+      }
+      .toSet
 
     target.value.mkdirs()
     val packageFile = target.value / s"${moduleName.value}-gatling-enterprise-${version.value}.jar"
@@ -67,7 +90,7 @@ class TaskEnterprisePackage(config: Configuration) {
       .createEnterprisePackage(
         classesDirectories.asJava,
         gatlingDependencies.asJava,
-        nonGatlingDependencies.asJava,
+        (nonGatlingDependencies ++ internalDependencies).asJava,
         rootModule.organization,
         rootModule.name,
         rootModule.revision,
@@ -83,9 +106,9 @@ class TaskEnterprisePackage(config: Configuration) {
   val legacyPackageEnterpriseJar: InitializeTask[File] = Def.sequential(
     Def.task {
       val newCommand = config.id match {
-        case Test.id            => "Gatling / enterprisePackage"
-        case IntegrationTest.id => "GatlingIt / enterprisePackage"
-        case _                  => "Gatling / enterprisePackage or GatlingIt / enterprisePackage"
+        case Test.id                   => "Gatling / enterprisePackage"
+        case Compat.IntegrationTest.id => "GatlingIt / enterprisePackage"
+        case _                         => "Gatling / enterprisePackage or GatlingIt / enterprisePackage"
       }
       streams.value.log.warn(
         s"""Task ${config.id} / assembly is deprecated and will be removed in a future version.

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseStart.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterpriseStart.scala
@@ -25,7 +25,7 @@ import io.gatling.sbt.GatlingKeys._
 import io.gatling.sbt.settings.gatling.EnterpriseUtils.InitializeInputTask
 import io.gatling.sbt.settings.gatling.TaskEnterpriseStart.CommandArgs.CommandArgsParser
 
-import sbt.{ Configuration, Def }
+import sbt._
 import sbt.Keys._
 import sbt.complete.DefaultParsers._
 import sbt.internal.util.ManagedLogger

--- a/src/main/scala/io/gatling/sbt/utils/ReportUtils.scala
+++ b/src/main/scala/io/gatling/sbt/utils/ReportUtils.scala
@@ -103,9 +103,9 @@ private[gatling] object ReportUtils {
    */
   def allReports(reportsFolder: File): Seq[Report] = {
     val reports = for {
-      directory <- (reportsFolder ** allReportsFilter).get
-      reportFolderRegex(simulationId, timestamp) <- reportFolderRegex findFirstIn directory.getName
-    } yield Report(directory, directory.getName, simulationId, timestamp)
+      directory <- (reportsFolder ** allReportsFilter).get()
+      matched <- reportFolderRegex.findFirstMatchIn(directory.getName)
+    } yield Report(directory, directory.getName, matched.group(1), matched.group(2))
     reports.toList.sorted
   }
 

--- a/src/sbt-test/gatling-sbt/enterpriseAssembly/project/build.properties
+++ b/src/sbt-test/gatling-sbt/enterpriseAssembly/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.12.13

--- a/src/sbt-test/gatling-sbt/enterpriseAssembly/test
+++ b/src/sbt-test/gatling-sbt/enterpriseAssembly/test
@@ -1,30 +1,38 @@
+# Paths are matched with a leading `**/` recursive glob so the assertions hold on both sbt 1.x
+# (flat `target/<config>` layout) and sbt 2.x (`target/out/jvm/scala-<v>/<project>/<config>` layout).
+# Each `clean` is followed by an `absent` assertion so a leftover jar from a previous section cannot
+# satisfy the next section's `exists` assertion.
+
 ######################################
 ## Gatling enterprisePackage tests ##
 ######################################
 
 > Gatling / enterprisePackage
-$ exists target/gatling/my-test-project-gatling-enterprise-1.2.3.jar
+$ exists **/gatling/my-test-project-gatling-enterprise-1.2.3.jar
 
 ########################################
 ## GatlingIt enterprisePackage tests ##
 ########################################
 
 > clean
+$ absent **/my-test-project-gatling-enterprise-1.2.3.jar
 > GatlingIt / enterprisePackage
-$ exists target/gatling-it/my-test-project-gatling-enterprise-1.2.3.jar
+$ exists **/gatling-it/my-test-project-gatling-enterprise-1.2.3.jar
 
 ##################################
 ## Legacy Test / assembly tests ##
 ##################################
 
 > clean
+$ absent **/my-test-project-gatling-enterprise-1.2.3.jar
 > Test / assembly
-$ exists target/my-test-project-gatling-enterprise-1.2.3.jar
+$ exists **/my-test-project-gatling-enterprise-1.2.3.jar
 
 ##################################
 ## Legacy It / assembly tests ##
 ##################################
 
 > clean
+$ absent **/my-test-project-gatling-enterprise-1.2.3.jar
 > It / assembly
-$ exists target/my-test-project-gatling-enterprise-1.2.3.jar
+$ exists **/my-test-project-gatling-enterprise-1.2.3.jar

--- a/src/sbt-test/gatling-sbt/multiModule/build.sbt
+++ b/src/sbt-test/gatling-sbt/multiModule/build.sbt
@@ -1,0 +1,35 @@
+import java.util.jar.JarFile
+
+ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / version := "1.2.3"
+
+val gatlingVersion = "3.15.0"
+
+val checkPackage = taskKey[Unit]("Checks that the enterprise package contains the classes of this module and of its internal dependencies")
+
+lazy val lib = project
+
+lazy val loadtest = project
+  .enablePlugins(GatlingPlugin)
+  .dependsOn(lib)
+  .settings(
+    libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % Test,
+    libraryDependencies += "io.gatling"            % "gatling-test-framework"    % gatlingVersion % Test,
+    checkPackage := {
+      val jar = (Gatling / enterprisePackage).value
+      val jarFile = new JarFile(jar)
+      val entries =
+        try {
+          val builder = Set.newBuilder[String]
+          val en = jarFile.entries()
+          while (en.hasMoreElements) builder += en.nextElement().getName
+          builder.result()
+        } finally jarFile.close()
+      def checkContains(entry: String): Unit =
+        if (!entries.contains(entry)) sys.error(s"Missing entry $entry in enterprise package $jar")
+      // Simulation classes from this module
+      checkContains("basic/MultiModuleSimulation.class")
+      // Classes from the internal `lib` module dependency
+      checkContains("lib/SimulationConfig.class")
+    }
+  )

--- a/src/sbt-test/gatling-sbt/multiModule/lib/src/main/scala/lib/SimulationConfig.scala
+++ b/src/sbt-test/gatling-sbt/multiModule/lib/src/main/scala/lib/SimulationConfig.scala
@@ -1,0 +1,5 @@
+package lib
+
+object SimulationConfig {
+  val BaseUrl = "http://computer-database.gatling.io"
+}

--- a/src/sbt-test/gatling-sbt/multiModule/loadtest/src/test/scala/basic/MultiModuleSimulation.scala
+++ b/src/sbt-test/gatling-sbt/multiModule/loadtest/src/test/scala/basic/MultiModuleSimulation.scala
@@ -1,0 +1,19 @@
+package basic
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+import lib.SimulationConfig
+
+class MultiModuleSimulation extends Simulation {
+  val httpProtocol = http
+    .baseUrl(SimulationConfig.BaseUrl)
+    .disableFollowRedirect
+
+  val scn = scenario("Scenario name")
+    .group("Login") {
+      exec(http("request_1").get("/").check(status.is(303)))
+    }
+
+  setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+}

--- a/src/sbt-test/gatling-sbt/multiModule/project/plugins.sbt
+++ b/src/sbt-test/gatling-sbt/multiModule/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.gatling" % "gatling-sbt" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/gatling-sbt/multiModule/test
+++ b/src/sbt-test/gatling-sbt/multiModule/test
@@ -1,0 +1,6 @@
+# Build the enterprise package of a module that depends on another module of the same build, and
+# verify that the package contains the classes of both. On sbt 1.x the internal dependency reaches
+# the package through the class directories found on the classpath; on sbt 2.x (where the classpath
+# carries packaged jars) it is packaged as an extra library jar and unpacked into the fat jar.
+
+> loadtest/checkPackage

--- a/src/sbt-test/gatling-sbt/runTests/project/build.properties
+++ b/src/sbt-test/gatling-sbt/runTests/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.9

--- a/src/sbt-test/gatling-sbt/runTests/test
+++ b/src/sbt-test/gatling-sbt/runTests/test
@@ -1,35 +1,40 @@
+# Paths are matched with a leading `**/` recursive glob so the assertions hold on both sbt 1.x
+# (flat `target/<config>` layout) and sbt 2.x (`target/out/jvm/scala-<v>/<project>/<config>` layout).
+# Report folders are checked via `**/<config>/*/index.html` (an actual Gatling report) rather than the
+# `<config>` directory itself, so they don't match sbt's per-config `streams/<config>` directory.
+
 #################################
 ## Gatling configuration tests ##
 #################################
 
 # check that there is no JUnit report before running unit tests
-$ absent target/test-reports
+$ absent **/test-reports
 
 # Run unit tests:
 # * Check that there is a JUnit report generated
 > test
-$ exists target/test-reports/TEST-unit.Spec.xml
+$ exists **/test-reports/TEST-unit.Spec.xml
 
 # check that there no reports before running test
-$ absent target/gatling
+$ absent **/gatling/*/index.html
 
 # Run the BasicExampleSimulationSucceeds simulation:
 # * Expect that the task succeeds
 # * Expect that a new report has been created in target/gatling
 > Gatling / testOnly basic.BasicExampleSimulationSucceeds
-$ exists target/gatling
-$ exists target/test-reports/TEST-basic.BasicExampleSimulationSucceeds.xml
+$ exists **/gatling/*/index.html
+$ exists **/test-reports/TEST-basic.BasicExampleSimulationSucceeds.xml
 
 # Run the clean task:
 # * Expect that the task succeeds
 # * Expect that the target/gatling folder has been deleted
 > Gatling / clean
-$ absent target/gatling
+$ absent **/gatling/*/index.html
 
 # Run the BasicExampleSimulationFails simulation:
 # * Expect that the task fails
 -> Gatling / testOnly basic.BasicExampleSimulationFails
-$ exists target/test-reports/TEST-basic.BasicExampleSimulationFails.xml
+$ exists **/test-reports/TEST-basic.BasicExampleSimulationFails.xml
 
 ###################################
 ## GatlingIt configuration tests ##
@@ -38,25 +43,25 @@ $ exists target/test-reports/TEST-basic.BasicExampleSimulationFails.xml
 # Run integration tests:
 # * Check that there is a JUnit report generated
 > IntegrationTest / test
-$ exists target/it-reports/TEST-integration.ItSpec.xml
+$ exists **/it-reports/TEST-integration.ItSpec.xml
 
 # check that there no reports before running test
-$ absent target/gatling-it
+$ absent **/gatling-it/*/index.html
 
 # Run the BasicExampleSimulationSucceeds simulation:
 # * Expect that the task succeeds
 # * Expect that a new report has been created in target/gatling
 > GatlingIt / testOnly basic.BasicItExampleSimulationSucceeds
-$ exists target/gatling-it
-$ exists target/it-reports/TEST-basic.BasicItExampleSimulationSucceeds.xml
+$ exists **/gatling-it/*/index.html
+$ exists **/it-reports/TEST-basic.BasicItExampleSimulationSucceeds.xml
 
 # Run the clean task:
 # * Expect that the task succeeds
 # * Expect that the target/gatling folder has been deleted
-> GatlingIT / clean
-$ absent target/gatling-it
+> GatlingIt / clean
+$ absent **/gatling-it/*/index.html
 
 # Run the BasicExampleSimulationFails simulation:
 # * Expect that the task fails
 -> GatlingIt / testOnly basic.BasicItExampleSimulationFails
-$ exists target/it-reports/TEST-basic.BasicItExampleSimulationFails.xml
+$ exists **/it-reports/TEST-basic.BasicItExampleSimulationFails.xml


### PR DESCRIPTION
## What

Cross-builds and cross-publishes the plugin for both sbt 1.x and sbt 2.x:

| Axis | Scala | sbt (pluginCrossBuild) | Published artifact |
|------|-------|------------------------|--------------------|
| sbt 1 | 2.12.21 | 1.12.13 | `gatling-sbt_2.12_1.0` |
| sbt 2 | 3.8.4  | 2.0.2  | `gatling-sbt_sbt2_3` |

The two coordinates don't collide, so a single `+release` publishes both.

## How

- `build.sbt`: `crossScalaVersions`, a per-axis `pluginCrossBuild / sbtVersion`
  and `gatlingCompilerRelease` (11 for 2.12, 17 for 3), and an explicit
  `unmanagedSourceDirectories` entry (this build sets `crossPaths := false`,
  which otherwise drops the `scala-<v>` source dirs).
- An `io.gatling.sbt.Compat` object, split into `src/main/scala-2.12` and
  `src/main/scala-3`, isolates the three places the sbt 1/2 APIs differ:
  - the `IntegrationTest` configuration removed in sbt 2 (recreated with the
    same id/name so `IntegrationTest / …`, `src/it`, `target/it-reports` are
    unchanged; `testReportSettings` re-added since sbt 2's JUnit plugin only
    wires `Test`);
  - the virtual-file classpath model (entries resolved via `xsbti.FileConverter`);
  - sbt 2's on-disk task cache (side-effecting/File-returning tasks opt out
    via `Def.uncached`).
  Every other source file stays shared and compiles on both Scala versions.
- sbt 2's `fullClasspath` exports packaged jars rather than class directories,
  so simulation scanning reads `classDirectory` directly (still unioned with
  any directory entries found on the classpath, for `exportJars := false`).
- Internal (inter-project) dependencies: on sbt 1 they reach the enterprise
  package as class directories found on the classpath; on sbt 2 they are
  packaged as extra library jars instead (resolved from
  `internalDependencyClasspath` with their module IDs, the project's own
  products excluded) — the same approach as the Maven and Gradle plugins,
  whose reactor artifacts also flow in as extra dependencies. A new
  `multiModule` scripted test builds a two-module project and asserts the
  packaged jar contains the classes of both modules, on both sbt versions.
- CI runs `+headerCheck`, `+test` and `+scripted`; scripted assertions use
  `**/` globs to hold on both the flat (sbt 1) and nested (sbt 2) `target`
  layouts, and each `clean` in `enterpriseAssembly` is followed by an
  `absent` assertion so leftover jars can't satisfy later `exists` checks.

## Verified locally

Both axes: `+compile` (main+test), `+test` (21/21), `+scripted` (all three test
projects, including the new `multiModule` one), `+publishM2` (distinct
coordinates above), and the static checks (`+headerCheck`, scalafmt, scalafix).

## Not exercised locally — reviewer notes

- **Release paths** (`+releasePublishArtifactsAction`, enterprise deploy/start)
  need Sonatype / Gatling Enterprise credentials, so only `publishM2` was run.
- **sbt 2 task caching on input tasks**: the OSS/enterprise *input* tasks
  (`generateReport`, `startRecorder`, `enterpriseDeploy`, `enterpriseStart`)
  were **not** opted out of sbt 2's caching — they aren't covered by scripted,
  and they compiled without sbt 2 demanding a cache format (unlike the built-in
  `clean`, which did and is fixed here). Left as-is deliberately; flagging as a
  follow-up if any prove non-idempotent under sbt 2.
- **Scala Steward**: `val scala3 = "3.8.4"` must track the exact Scala version
  sbt 2.0.x ships (TASTy compatibility) — it should not be bumped independently
  of the sbt-2 version.
- **scalafmt/scalafix and `src/main/scala-3`**: those checks run on the default
  (Scala 2.12) axis only, so the sbt-2 `Compat.scala` is not covered — the
  shared scalafmt config's `scala213` dialect cannot parse its (required)
  `inline def`. Covering it would need a dialect `fileOverride` in
  gatling-build-plugin's shared scalafmt config.
