### PR TITLE
Prepare cross-built release for sbt 1.x and sbt 2.x

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -55,7 +55,7 @@ jobs:
           RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
         run: |
           sbt "gatlingWriteBumpVersion $RELEASE_TYPE"
-          export CURRENT_TAG="v$(cat target/gatlingNextVersion)"
+          export CURRENT_TAG="v$(cat target/out/jvm/u/gatling-build-plugin/gatlingNextVersion)"
           echo "tag='$CURRENT_TAG'"
           echo "::set-output name=tag::$CURRENT_TAG"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
           SONATYPE_SBT: ${{ secrets.SONATYPE_SBT }}
           SONATYPE_PGP_SECRET: ${{ secrets.SONATYPE_PGP_SECRET }}
         run: |
-          mkdir --parents ~/.sbt/1.0 || true
-          echo "$SONATYPE_SBT" > ~/.sbt/1.0/sonatype.sbt
+          mkdir --parents ~/.config/sbt/2 || true
+          echo "$SONATYPE_SBT" > ~/.config/sbt/2/sonatype.sbt
           echo -n "$SONATYPE_PGP_SECRET" | base64 --decode | gpg --batch --import
 
       #     - name: Cache
@@ -45,7 +45,7 @@ jobs:
         env:
           PGP_PASSPHRASE: ${{ secrets.SONATYPE_PGP_PASSPHRASE }}
         run: |
-          sbt "release with-defaults"
+          sbt -v "release with-defaults"
           export VERSION="$(cat target/release-info)"
           echo "version=$VERSION" # DO NOT REMOVE, because of bad parsing for outputs
           echo "::set-output name=version::$VERSION"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,42 @@
+version = 3.11.1
+runner.dialect = scala3
+align = more
+maxColumn = 160
+docstrings.style = Asterisk
+danglingParentheses.preset = true
+assumeStandardLibraryStripMargin = true
+align.tokens."+" = [
+  {code = "%" , owner = "Term.ApplyInfix"},
+  {code = "%%", owner = "Term.ApplyInfix"}
+]
+rewriteTokens {
+  "⇒": "=>"
+  "←": "<-"
+  "→": "->"
+}
+spaces.inImportCurlyBraces = true
+rewrite.rules = [
+  PreferCurlyFors,
+  RedundantBraces,
+  RedundantParens,
+  SortImports,
+  SortModifiers,
+]
+rewrite.sortModifiers.order = [
+  "`override`"
+  "`private`"
+  "`protected`"
+  "`sealed`"
+  "`abstract`"
+  "`lazy`"
+  "`implicit`"
+  "`final`"
+]
+includeNoParensInSelectChains = false
+binPack.literalArgumentLists = false
+project.git = true
+lineEndings = preserve
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.generalExpressions = false
+rewrite.redundantBraces.ifElseExpressions = false
+rewrite.redundantBraces.defnBodies = "all"

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,15 @@
 // Scala 2.12 builds the plugin for sbt 1.x, Scala 3 builds it for sbt 2.x.
-// sbt 2.0.x is built with Scala 3.8.4, and the plugin must use that exact version so it can read sbt's TASTy.
 val scala212 = "2.12.21"
-val scala3 = "3.8.4"
+// For sbt 2.0.x, the plugin must use the exact same version as sbt itself so it can read sbt's TASTy.
+val scala3 = settingKey[String]("The Scala 3 version used when building for for sbt 2.x")
+scala3 := scala_version_from_sbt_version.ScalaVersionFromSbtVersion(sbtVersion.value)
 
 lazy val gatlingSbt = rootProject
   .enablePlugins(BuildInfoPlugin, SbtPlugin, GatlingOssPlugin)
   .settings(
     name := "gatling-sbt",
     scalaVersion := scala212,
-    crossScalaVersions := Seq(scala212, scala3),
+    crossScalaVersions := Seq(scala212, scala3.value),
     sbtPlugin := true,
     githubPath := "gatling/gatling-sbt-plugin",
     sbtPluginPublishLegacyMavenStyle := false,

--- a/build.sbt
+++ b/build.sbt
@@ -1,79 +1,79 @@
-enablePlugins(BuildInfoPlugin, SbtPlugin, GatlingOssPlugin)
-
-ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
-
 // Scala 2.12 builds the plugin for sbt 1.x, Scala 3 builds it for sbt 2.x.
 // sbt 2.0.x is built with Scala 3.8.4, and the plugin must use that exact version so it can read sbt's TASTy.
 val scala212 = "2.12.21"
 val scala3 = "3.8.4"
 
-name := "gatling-sbt"
-scalaVersion := scala212
-crossScalaVersions := Seq(scala212, scala3)
-sbtPlugin := true
-githubPath := "gatling/gatling-sbt-plugin"
-sbtPluginPublishLegacyMavenStyle := false
+lazy val gatlingSbt = rootProject
+  .enablePlugins(BuildInfoPlugin, SbtPlugin, GatlingOssPlugin)
+  .settings(
+    name := "gatling-sbt",
+    scalaVersion := scala212,
+    crossScalaVersions := Seq(scala212, scala3),
+    sbtPlugin := true,
+    githubPath := "gatling/gatling-sbt-plugin",
+    sbtPluginPublishLegacyMavenStyle := false,
 
-// GatlingPublishPlugin sets `crossPaths := false`, which disables sbt's automatic `scala-<version>` source
-// directories. We add them back explicitly so sbt-1-only (Scala 2.12) and sbt-2-only (Scala 3) sources can
-// coexist: `src/main/scala-2.12` for sbt 1.x and `src/main/scala-3` for sbt 2.x.
-Compile / unmanagedSourceDirectories += {
-  val base = (Compile / sourceDirectory).value
-  scalaBinaryVersion.value match {
-    case "2.12" => base / "scala-2.12"
-    case _      => base / "scala-3"
-  }
-}
+    // GatlingPublishPlugin sets `crossPaths := false`, which disables sbt's automatic `scala-<version>` source
+    // directories. We add them back explicitly so sbt-1-only (Scala 2.12) and sbt-2-only (Scala 3) sources can
+    // coexist: `src/main/scala-2.12` for sbt 1.x and `src/main/scala-3` for sbt 2.x.
+    Compile / unmanagedSourceDirectories += {
+      val base = (Compile / sourceDirectory).value
+      scalaBinaryVersion.value match {
+        case "2.12" => base / "scala-2.12"
+        case _      => base / "scala-3"
+      }
+    },
 
-// sbt 1.x supports JDK 8+, so the Scala 2.12 build targets Java 11; sbt 2.x requires JDK 17+, and Scala 3
-// on recent JDKs no longer accepts `-release 11`, so the Scala 3 build targets Java 17.
-gatlingCompilerRelease := {
-  scalaBinaryVersion.value match {
-    case "2.12" => 11
-    case _      => 17
-  }
-}
+    // sbt 1.x supports JDK 8+, so the Scala 2.12 build targets Java 11; sbt 2.x requires JDK 17+, and Scala 3
+    // on recent JDKs no longer accepts `-release 11`, so the Scala 3 build targets Java 17.
+    gatlingCompilerRelease := {
+      scalaBinaryVersion.value match {
+        case "2.12" => 11
+        case _      => 17
+      }
+    },
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest"                         % "3.2.20" % Test,
-  "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.25.1",
-  "io.gatling"     % "gatling-shared-cli"                % "0.0.7"
-)
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest"                         % "3.2.20" % Test,
+      "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.25.1",
+      "io.gatling"     % "gatling-shared-cli"                % "0.0.7"
+    ),
 
-scriptedLaunchOpts := {
-  scriptedLaunchOpts.value ++
-    Seq(
-      "-Xmx512m",
-      "-Dgatling.data.enableAnalytics=false",
-      "-Dplugin.version=" + version.value
-    )
-}
+    scriptedLaunchOpts := {
+      scriptedLaunchOpts.value ++
+        Seq(
+          "-Xmx512m",
+          "-Dgatling.data.enableAnalytics=false",
+          "-Dplugin.version=" + version.value
+        )
+    },
 
-scriptedBufferLog := false
+    scriptedBufferLog := false,
 
-pluginCrossBuild / sbtVersion := {
-  scalaBinaryVersion.value match {
-    case "2.12" => "1.12.13"
-    case _      => "2.0.2"
-  }
-}
-gatlingDevelopers := Seq(
-  GatlingDeveloper(
-    "slandelle@gatling.io",
-    "Stéphane Landelle",
-    true
-  ),
-  GatlingDeveloper(
-    "sbrevet@gatling.io",
-    "Sébastien Brevet",
-    true
-  ),
-  GatlingDeveloper(
-    "tpetillot@gatling.io",
-    "Thomas Petillot",
-    true
+    pluginCrossBuild / sbtVersion := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.12.13"
+        case _      => "2.0.2"
+      }
+    },
+    gatlingDevelopers := Seq(
+      GatlingDeveloper(
+        "slandelle@gatling.io",
+        "Stéphane Landelle",
+        true
+      ),
+      GatlingDeveloper(
+        "sbrevet@gatling.io",
+        "Sébastien Brevet",
+        true
+      ),
+      GatlingDeveloper(
+        "tpetillot@gatling.io",
+        "Thomas Petillot",
+        true
+      )
+    ),
+
+    buildInfoKeys := Seq[BuildInfoKey](name, version),
+    buildInfoPackage := "io.gatling.sbt"
   )
-)
-
-buildInfoKeys := Seq[BuildInfoKey](name, version)
-buildInfoPackage := "io.gatling.sbt"

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ lazy val gatlingSbt = rootProject
     githubPath := "gatling/gatling-sbt-plugin",
     sbtPluginPublishLegacyMavenStyle := false,
 
+    scalafmtConfig := (ThisBuild / baseDirectory).value / ".scalafmt.conf",
+
     // GatlingPublishPlugin sets `crossPaths := false`, which disables sbt's automatic `scala-<version>` source
     // directories. We add them back explicitly so sbt-1-only (Scala 2.12) and sbt-2-only (Scala 3) sources can
     // coexist: `src/main/scala-2.12` for sbt 1.x and `src/main/scala-3` for sbt 2.x.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.14
+sbt.version=2.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,7 @@
 addSbtPlugin("io.gatling"   % "gatling-build-plugin" % "6.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo"        % "0.13.1")
 
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+libraryDependencies ++= Seq(
+  "org.scala-sbt"      %% "scripted-plugin"                % sbtVersion.value,
+  "com.github.xuwei-k" %% "scala-version-from-sbt-version" % "0.1.0"
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.gatling"   % "gatling-build-plugin" % "6.4.5")
+addSbtPlugin("io.gatling"   % "gatling-build-plugin" % "6.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo"        % "0.13.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala-3/io/gatling/sbt/Compat.scala
+++ b/src/main/scala-3/io/gatling/sbt/Compat.scala
@@ -23,15 +23,15 @@ import sbt.plugins.JUnitXmlReportPlugin.autoImport.testReportSettings
 import xsbti.{ FileConverter, HashedVirtualFileRef }
 
 /**
- * sbt 2.x implementations of the few APIs that differ between sbt 1.x and sbt 2.x. The sbt 1.x counterparts live under `src/main/scala-2.12`, so that the
- * rest of the plugin's sources can be shared between both sbt versions.
+ * sbt 2.x implementations of the few APIs that differ between sbt 1.x and sbt 2.x. The sbt 1.x counterparts live under `src/main/scala-2.12`, so that the rest
+ * of the plugin's sources can be shared between both sbt versions.
  */
 private[gatling] object Compat {
 
   /**
-   * The built-in `IntegrationTest` configuration was removed in sbt 2.x, so we recreate the exact one sbt 1.x used to provide: id `IntegrationTest`,
-   * Ivy name `it`, extending `Runtime`. Keeping the same id and name preserves how it is referenced on the command line (`IntegrationTest / ...` and
-   * `It / ...`) and where its sources (`src/it`) and reports (`target/it-reports`) live.
+   * The built-in `IntegrationTest` configuration was removed in sbt 2.x, so we recreate the exact one sbt 1.x used to provide: id `IntegrationTest`, Ivy name
+   * `it`, extending `Runtime`. Keeping the same id and name preserves how it is referenced on the command line (`IntegrationTest / ...` and `It / ...`) and
+   * where its sources (`src/it`) and reports (`target/it-reports`) live.
    */
   val IntegrationTest: Configuration = Configuration.of("IntegrationTest", "it").extend(Runtime)
 
@@ -44,23 +44,23 @@ private[gatling] object Compat {
     inConfig(IntegrationTest)(Defaults.testSettings ++ testReportSettings)
 
   /**
-   * Resolves the actual files backing a classpath. On sbt 2.x each classpath entry carries a virtual file reference that must be resolved through the
-   * build's [[xsbti.FileConverter]].
+   * Resolves the actual files backing a classpath. On sbt 2.x each classpath entry carries a virtual file reference that must be resolved through the build's
+   * [[xsbti.FileConverter]].
    */
   def toFiles(classpath: Def.Classpath, converter: FileConverter): Seq[File] =
     classpath.map(entry => converter.toPath(entry.data).toFile)
 
   /**
    * The project's compiled class directories, used to scan for simulations. On sbt 2.x the classpath usually carries packaged jars rather than class
-   * directories, so we use the `classDirectory` locations directly (compilation is triggered by evaluating `fullClasspath` at the call site). Directory
-   * entries still found on the classpath (`exportJars := false`) are included as well, mirroring the sbt 1.x behaviour.
+   * directories, so we use the `classDirectory` locations directly (compilation is triggered by evaluating `fullClasspath` at the call site). Directory entries
+   * still found on the classpath (`exportJars := false`) are included as well, mirroring the sbt 1.x behaviour.
    */
   def classesDirectories(fullClasspath: Def.Classpath, classDirectories: Seq[File], converter: FileConverter): Seq[File] =
     (classDirectories ++ toFiles(fullClasspath, converter)).filter(_.isDirectory).distinct
 
   /**
-   * The internal (inter-project) dependencies to package as extra library jars, with their module IDs. On sbt 2.x internal dependencies appear on the
-   * classpath as packaged jars carrying their module ID as a string attribute.
+   * The internal (inter-project) dependencies to package as extra library jars, with their module IDs. On sbt 2.x internal dependencies appear on the classpath
+   * as packaged jars carrying their module ID as a string attribute.
    */
   def internalDependencies(internalDependencyClasspath: Def.Classpath, converter: FileConverter): Seq[(ModuleID, File)] =
     internalDependencyClasspath
@@ -72,15 +72,15 @@ private[gatling] object Compat {
       .filter { case (_, file) => file.isFile }
 
   /**
-   * Adapts the file produced for the `packageBin` task to the value type that key expects. On sbt 2.x it is a virtual file reference resolved through
-   * the build's [[xsbti.FileConverter]].
+   * Adapts the file produced for the `packageBin` task to the value type that key expects. On sbt 2.x it is a virtual file reference resolved through the
+   * build's [[xsbti.FileConverter]].
    */
   def toPackagedArtifact(file: File, converter: FileConverter): HashedVirtualFileRef =
     converter.toVirtualFile(file.toPath)
 
   /**
-   * Opts a task out of sbt 2.x's on-disk task caching, which rejects [[java.io.File]] results and requires a `JsonFormat` for other results. Delegates
-   * to sbt 2.x's `Def.uncached` marker.
+   * Opts a task out of sbt 2.x's on-disk task caching, which rejects [[java.io.File]] results and requires a `JsonFormat` for other results. Delegates to sbt
+   * 2.x's `Def.uncached` marker.
    */
   inline def uncached[A](inline task: A): A =
     Def.uncached(task)

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
@@ -37,7 +37,7 @@ class TaskEnterprisePackage(config: Configuration) {
     val logger = streams.value.log
     moduleSettings.value match {
       case config: ModuleDescriptorConfiguration => config
-      case x =>
+      case x                                     =>
         logger.error(s"gatling-sbt expected a ModuleDescriptorConfiguration, but got a ${x.getClass}")
         throw ErrorAlreadyLoggedException
     }

--- a/src/test/scala/io/gatling/sbt/utils/ReportUtilsSpec.scala
+++ b/src/test/scala/io/gatling/sbt/utils/ReportUtilsSpec.scala
@@ -121,8 +121,10 @@ class ReportUtilsSpec extends AnyFlatSpec with Matchers with ParserMatchers {
     val reportNames = allReportNames(new File("src/test/resources/reports"))
 
     reportNames should contain only (
-      "basicsimulation-20140404205455", "basicsimulation-20140406205455",
-      "basicsimulation-20140408205455", "advancedsimulation-20140404205455"
+      "basicsimulation-20140404205455",
+      "basicsimulation-20140406205455",
+      "basicsimulation-20140408205455",
+      "advancedsimulation-20140404205455"
     )
   }
 }


### PR DESCRIPTION
Notes:
- Updated build definition to sbt 2 similarly to what was done for `gatling-build-plugin`
- I added an override of the scalafmt configuration to set `runner.dialect = scala3`, so that `src/main/scala-3/io/gatling/sbt/Compat.scala` can format properly (it uses syntax which is invalid in the Scala 2 dialect); but ideally we should probably support this in the `gatling-build-plugin` instead...
- I added a way to avoid specifying the exact Scala 3 version for the sbt 2.x build, using a plugin to match the version used in sbt itself. If we agree on this, we can do the same in our other plugins.