### PR TITLE
fix: correctly handle internal files in enterprisePackage for sbt 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val gatlingSbt = rootProject
 
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest"                         % "3.2.20" % Test,
-      "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.25.2",
+      "io.gatling"     % "gatling-enterprise-plugin-commons" % "1.26.0",
       "io.gatling"     % "gatling-shared-cli"                % "0.0.7"
     ),
 

--- a/src/main/scala-2.12/io/gatling/sbt/Compat.scala
+++ b/src/main/scala-2.12/io/gatling/sbt/Compat.scala
@@ -48,22 +48,6 @@ private[gatling] object Compat {
     classpath.map(_.data)
 
   /**
-   * The project's own compiled class directories, used to scan for simulations. On sbt 1.x they appear directly in the classpath as directories, so we keep the
-   * historical behaviour of filtering the full classpath (which also captures inter-project class directories).
-   */
-  def classesDirectories(fullClasspath: Def.Classpath, classDirectories: Seq[File], converter: FileConverter): Seq[File] =
-    toFiles(fullClasspath, converter).filter(_.isDirectory)
-
-  /**
-   * The internal (inter-project) dependencies to package as extra library jars, with their module IDs. On sbt 1.x internal dependencies usually appear on the
-   * classpath as class directories and are already packaged through [[classesDirectories]], so only jar entries (`exportJars := true`) are returned here.
-   */
-  def internalDependencies(internalDependencyClasspath: Def.Classpath, converter: FileConverter): Seq[(ModuleID, File)] =
-    internalDependencyClasspath
-      .filter(_.data.isFile)
-      .flatMap(entry => entry.get(Keys.moduleID.key).map(_ -> entry.data))
-
-  /**
    * Adapts the file produced for the `packageBin` task to the value type that key expects. On sbt 1.x it is a plain [[java.io.File]].
    */
   def toPackagedArtifact(file: File, converter: FileConverter): File =

--- a/src/main/scala-3/io/gatling/sbt/Compat.scala
+++ b/src/main/scala-3/io/gatling/sbt/Compat.scala
@@ -51,27 +51,6 @@ private[gatling] object Compat {
     classpath.map(entry => converter.toPath(entry.data).toFile)
 
   /**
-   * The project's compiled class directories, used to scan for simulations. On sbt 2.x the classpath usually carries packaged jars rather than class
-   * directories, so we use the `classDirectory` locations directly (compilation is triggered by evaluating `fullClasspath` at the call site). Directory entries
-   * still found on the classpath (`exportJars := false`) are included as well, mirroring the sbt 1.x behaviour.
-   */
-  def classesDirectories(fullClasspath: Def.Classpath, classDirectories: Seq[File], converter: FileConverter): Seq[File] =
-    (classDirectories ++ toFiles(fullClasspath, converter)).filter(_.isDirectory).distinct
-
-  /**
-   * The internal (inter-project) dependencies to package as extra library jars, with their module IDs. On sbt 2.x internal dependencies appear on the classpath
-   * as packaged jars carrying their module ID as a string attribute.
-   */
-  def internalDependencies(internalDependencyClasspath: Def.Classpath, converter: FileConverter): Seq[(ModuleID, File)] =
-    internalDependencyClasspath
-      .flatMap { entry =>
-        entry.get(Keys.moduleIDStr).map { str =>
-          Classpaths.moduleIdJsonKeyFormat.read(str) -> converter.toPath(entry.data).toFile
-        }
-      }
-      .filter { case (_, file) => file.isFile }
-
-  /**
    * Adapts the file produced for the `packageBin` task to the value type that key expects. On sbt 2.x it is a virtual file reference resolved through the
    * build's [[xsbti.FileConverter]].
    */

--- a/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
+++ b/src/main/scala/io/gatling/sbt/settings/gatling/TaskEnterprisePackage.scala
@@ -46,6 +46,29 @@ class TaskEnterprisePackage(config: Configuration) {
   val buildEnterprisePackage: InitializeTask[File] = Def.task {
     val moduleDescriptor = moduleDescriptorConfig.value
 
+    // The classpath (`fullclasspath`) consists of:
+    // - `exportedProducts` (1), classes and resources from this project
+    // - `dependencyClasspath`, itself consisting of:
+    //   - `internalDependencyClasspath` (2), from other projects in the same build
+    //   - `externalDependencyClasspath` (3), external libraries
+
+    // (1) `exportedProducts` from this specific project/configuration (i.e. classes and resources in "test" in this project)
+    val allProjectEntries = Compat.toFiles((config / exportedProducts).value, fileConverter.value)
+
+    // (2) `internalDependencyClasspath`, this includes classes/resources from:
+    // - other configurations this one depends on in the same project (normally the `Compile` configuration, i.e. classes and resources in "main" in this project)
+    // - other projects this one depends on using `.dependsOn()`
+    val allInternalDependencies = Compat.toFiles((config / internalDependencyClasspath).value, fileConverter.value)
+
+    // (1) and (2)
+    // On sbt 1.x they are directories (e.g. <my-project>/target/scala-2.13/test-classes/).
+    // On sbt 2.x they are JARs (e.g. target/out/jvm/scala-2.13.18/<my-project>/<my-project>_2.13-<version>>-tests.jar).
+    // For simplicity and consistency, we simply handle both directories and JARs either way.
+    val allInternalEntries = allInternalDependencies ++ allProjectEntries
+    val classesDirectories = allInternalEntries.filter(_.isDirectory)
+    val jarFiles = allInternalEntries.filter(_.isFile)
+
+    // (3) External dependencies (from `.libraryDependencies()`)  are collected with the DependenciesAnalyzer
     val DependenciesAnalysisResult(gatlingDependencies, nonGatlingDependencies) = DependenciesAnalyzer.analyze(
       dependencyResolution.value,
       updateConfiguration.value,
@@ -55,42 +78,17 @@ class TaskEnterprisePackage(config: Configuration) {
       moduleDescriptor
     )
 
-    // The compiled simulations live in the project's own class directories. On sbt 1.x these appear in the
-    // classpath as directories; on sbt 2.x the classpath instead carries packaged jars, so we get the class
-    // directories from `classDirectory`. Evaluating `fullClasspath` triggers compilation on both versions.
-    val classesDirectories = Compat.classesDirectories(
-      (config / fullClasspath).value,
-      Seq((config / classDirectory).value, (Compile / classDirectory).value),
-      fileConverter.value
-    )
-
-    val pluginLogger = EnterprisePluginIO.enterprisePluginLoggerTask.value
-
-    val rootModule = moduleDescriptor.module
-
-    // Internal (inter-project) dependencies exported as jars are packaged as extra library jars, like the
-    // Maven and Gradle plugins do (`DependenciesAnalyzer` only sees external modules, and on sbt 2.x internal
-    // dependencies no longer appear on the classpath as class directories). The project's own products are
-    // excluded: their classes are already packaged through `classesDirectories`.
-    val internalDependencies = Compat
-      .internalDependencies((config / internalDependencyClasspath).value, fileConverter.value)
-      .collect {
-        case (moduleId, jar) if moduleId.organization != rootModule.organization || moduleId.name != rootModule.name =>
-          new Dependency(
-            new Dependency.Id(moduleId.organization, moduleId.name, moduleId.revision, null),
-            jar
-          )
-      }
-      .toSet
-
     target.value.mkdirs()
     val packageFile = target.value / s"${moduleName.value}-gatling-enterprise-${version.value}.jar"
 
+    val pluginLogger = EnterprisePluginIO.enterprisePluginLoggerTask.value
+    val rootModule = moduleDescriptor.module
     new EnterprisePackager(pluginLogger)
       .createEnterprisePackage(
         classesDirectories.asJava,
+        jarFiles.asJava,
         gatlingDependencies.asJava,
-        (nonGatlingDependencies ++ internalDependencies).asJava,
+        nonGatlingDependencies.asJava,
         rootModule.organization,
         rootModule.name,
         rootModule.revision,


### PR DESCRIPTION
Motivation:

 Task enterprisePackage currently misses resource files from the project and from its internal dependencies within the same build.

In sbt 2.x, the internal classpath (the project + its internal dependencies within the same build) are made up of JARs instead of directories of individual files. We should directly support this mechanism instead of trying to work around it.

Modifications:

Get the content that needs to be packaged from `exportedProducts` and `internalDependencyClasspath`. Then make sure to support both directories and JAR files.

Handling of external libraries doesn't change.

Result:

The result of enterprisePackage now includes all resources that were missing.

-----

Depends on gatling/gatling-enterprise-plugin-commons#297