### PR TITLE
chore: stop relying on release-info file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,3 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.SONATYPE_PGP_PASSPHRASE }}
         run: |
           sbt -v "release with-defaults"
-          export VERSION="$(cat target/release-info)"
-          echo "version=$VERSION" # DO NOT REMOVE, because of bad parsing for outputs
-          echo "::set-output name=version::$VERSION"


### PR DESCRIPTION
Motivation:
This feature will be deleted from gatling-build-plugin

Modifications:
 * no usage, so remove the call

Result:
Less code, less bug