### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,17 +22,17 @@ jobs:
       JAVA_OPTS: "-Xmx6G"
       SBT_OPTS: "-Dsbt.ci=true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup JDK
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'zulu'
           java-version: '25'
           cache: 'sbt'
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1.5.7
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - name: Test
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,20 +34,20 @@ jobs:
           github.event.inputs.releaseType != 'minor-milestone' &&
           github.event.inputs.releaseType != 'patch-milestone'
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # indicates all history for all branches and tags
           token: ${{ secrets.GATLING_CI_TOKEN }} # for tag to trigger other workflows (release)
 
       - name: Setup JDK
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'zulu'
           java-version: '25'
           cache: 'sbt'
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1.5.7
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - name: Next version
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,16 @@ jobs:
       JAVA_OPTS: "-Xmx6G"
       SBT_OPTS: "-Dsbt.ci=true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup JDK
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'zulu'
           java-version: '25'
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1.5.7
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - name: Prepare environment
         env:


### PR DESCRIPTION
Pin third-party GitHub Actions to a full-length commit SHA (with the original ref kept as a trailing comment so Dependabot keeps bumping it) instead of a mutable tag.